### PR TITLE
fix: checkbox does not check correctly on filter change(querybar)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/ui",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/src/components/filters/CheckboxFilter.tsx
+++ b/packages/ui/src/components/filters/CheckboxFilter.tsx
@@ -91,8 +91,8 @@ const CheckboxFilter: React.FC<TermFilterProps> = ({
                                 key={`${filterGroup.field}-${filter.id}-${filter.data.count}-${selectedFilters.length}-${i}`}
                             >
                                 <Checkbox
+                                    checked={selectedFilters.some((f) => f.data.key === filter.data.key)}
                                     className={styles.fuiMcItemCheckbox}
-                                    defaultChecked={selectedFilters.some((f) => f.data.key === filter.data.key)}
                                     id={`input-${filter.data.key}`}
                                     name={`input-${filter.id}`}
                                     onChange={(e) => {


### PR DESCRIPTION
There is a bug on cqdg and kf, were when you change you selection in the querybar (updating the filters). The checkbox cannot represent the current status even if the proper value is sent to antd checkbox component

Before:

https://user-images.githubusercontent.com/98903/113296394-b2404300-92f9-11eb-8334-d8469d541976.mov

After:

https://user-images.githubusercontent.com/98903/113296423-bd936e80-92f9-11eb-8565-cb84bce8c408.mov

