### PR TITLE
fix toggle filters tag count to be displayed on the right

### DIFF
--- a/packages/style/components/filters/ToggleFilter.module.scss
+++ b/packages/style/components/filters/ToggleFilter.module.scss
@@ -5,13 +5,27 @@
     .radio {
         display: flex;
         flex-direction: column;
+        width: 100%;
+
         > * {
             margin-bottom: .8rem;
+            width: 100%;
+        }
+
+        > label {
+            align-items: center;
+            display: flex;
+        }
+        > label > span:last-child {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+            padding-right: 0px;
         }
     }
 
     .tag {
-        margin-left: .8rem;
+        margin-right: .8rem;
     }
 
     .fui-filter-sc-button {

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/style",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Design update for all projects

<img width="520" alt="Screen Shot 2021-04-01 at 6 20 28 PM" src="https://user-images.githubusercontent.com/98903/113324115-0574be80-9317-11eb-8e76-7417cefb51fe.png">
