### PR TITLE
feat: CLIN-1315 underline tooltipped protable column headers

### DIFF
--- a/packages/ui/src/components/ProTable/ColumnSelector/index.tsx
+++ b/packages/ui/src/components/ProTable/ColumnSelector/index.tsx
@@ -117,15 +117,11 @@ const ColumnSelector = ({ className = '', columns, columnStates, onChange, dicti
                                             return false;
                                         }
 
-                                        const title =
-                                            typeof foundColumn.title === 'string'
-                                                ? foundColumn.title
-                                                : foundColumn.displayTitle;
                                         const savedColumnState = getColumnStateByKey(localState.key);
                                         return (
                                             <SortableColumnItem
                                                 id={localState.key!}
-                                                label={title?.toString()!}
+                                                label={String(foundColumn.title)}
                                                 key={index}
                                                 checked={savedColumnState?.visible}
                                                 onChange={(e) => {

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -129,6 +129,22 @@ const ProTable = <RecordType extends object & { key: string } = any>({
         return customExtra;
     };
 
+    const generateColumnTitle = (column: ProColumnType) => {
+        const style: React.CSSProperties = {
+            textDecoration: 'underline dotted',
+        };
+        let title = column.tooltip ? <span style={style}>{column.title}</span> : column.title;
+        title = column.icon ? (
+            <Space size={3}>
+                {column.icon} {title}
+            </Space>
+        ) : (
+            title
+        );
+        title = column.tooltip ? <Tooltip title={column.tooltip}>{title}</Tooltip> : title;
+        return { ...column, title };
+    };
+
     return (
         <Space
             size={headerConfig.marginBtm}
@@ -216,7 +232,8 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                     .filter(({ visible }) => visible)
                     .sort((a, b) => a.index - b.index)
                     .map(({ key }) => columns.find((column) => column.key === key)!)
-                    .filter((column) => !isEmpty(column))}
+                    .filter((column) => !isEmpty(column))
+                    .map(generateColumnTitle)}
             ></Table>
         </Space>
     );

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -26,7 +26,8 @@ export interface IProTableDictionary {
 
 export interface ProColumnType<T = any> extends ColumnType<T> {
     key: string;
-    displayTitle?: string;
+    icon?: React.ReactElement;
+    tooltip?: string;
     defaultHidden?: boolean;
 }
 


### PR DESCRIPTION
# Underline (dotted) tooltipped ProTable column headers

Task: https://ferlab-crsj.atlassian.net/browse/CLIN-1315

## Description

The ProColumnType now has 2 new props : `icon` and `tooltip`.
The `title` prop is now used simply for providing the column name.
The `displayTitle` has been removed, it was used to provide a string as replacement for title when the `title` prop was assigned a node or element.

## Breaking change !
Any project using the ProTable component should be updated when using the new package.

## Testing
This can be tested along with this PR's branch :
https://github.com/Ferlab-Ste-Justine/clin-portal-ui/pull/119
