### PR TITLE
feat: SKFP-393 updateActiveQueryField now support RangeOperators

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -12,34 +12,39 @@ Styles are installed separately
 
 ## Developper
 
-- All work must be done based on master
-- All styles automatically reference to the @ferlab/styles package
-- Components should be added and tests in [storybook](../../storybook)
+-   All work must be done based on master
+-   All styles automatically reference to the @ferlab/styles package
+-   Components should be added and tests in [storybook](../../storybook)
 
 ### Development
 
-Steps to develop or debug the library in a real project
+Steps to develop or debug the libraries in a real project
 
-1. Make @ferlab/ui accessible to link
-   1. `npm link`
-2. Link the library in your project
-   1. `npm link @ferlab/ui`
+1. Make @ferlab/ui and @ferlab/style accessible to link
+    1. `npm link` inside @ferlab/ui folder
+    2. `npm link` inside @ferlab/style folder
+2. Link the libraries in your project
+    1. `npm link @ferlab/ui @ferlab/style`
+
+#### Duplicate React
 
 Linking the library will add the packages twice in the bundle, which could create some issues with `react` and `react-dom`. It's important to add an alias to use the host modules.
 
-e.g. in tsconfig | please refer to [clin-portal-ui](https://github.com/Ferlab-Ste-Justine/clin-portal-ui) for a working example. 
+e.g. in tsconfig | please refer to [clin-portal-ui](https://github.com/Ferlab-Ste-Justine/clin-portal-ui) for a working example.
 
 ```json
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "react": ["node_modules/react"],
-      "react-dom": ["node_modules/react-dom"]
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "react": ["node_modules/react"],
+            "react-dom": ["node_modules/react-dom"]
+        }
     }
-  }
 }
 ```
+
+This problem can also come up when you use npm link or an equivalent. In that case, your bundler might “see” two Reacts — one in application folder and one in your library folder. Assuming myapp and mylib are sibling folders, one possible fix is to run npm link ../myapp/node_modules/react from mylib. This should make the library use the application’s React copy.
 
 ### Storybook
 
@@ -59,13 +64,14 @@ npm start
 ```
 
 ### Publish new release
+
 To publish a new release once a PR as been validated and merged
 
 1. Try to install the package to make sure everything work corretly
     > cd [test dir] && npm i [full_path]/ferlab-ui/packages/ui
 2. Delete core folder to remove deleted files
     > rm -rf core/
-3. Prepare the package 
+3. Prepare the package
     > npm run build
 4. On master Update package.json version
 5. Push the new version

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/utils/useQueryBuilderState.tsx
+++ b/packages/ui/src/components/QueryBuilder/utils/useQueryBuilderState.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { isEmpty } from 'lodash';
 import { v4 } from 'uuid';
 
-import { BooleanOperators, TermOperators } from '../../../data/sqon/operators';
+import { BooleanOperators, RangeOperators, TermOperators } from '../../../data/sqon/operators';
 import { TSqonGroupOp } from '../../../data/sqon/types';
 import { ISyntheticSqon, MERGE_VALUES_STRATEGIES } from '../../../data/sqon/types';
 import {
@@ -137,7 +137,7 @@ export const updateActiveQueryField = ({
     field: string;
     value: Array<string | number | boolean>;
     merge_strategy?: MERGE_VALUES_STRATEGIES;
-    operator?: TermOperators;
+    operator?: TermOperators | RangeOperators;
     index?: string;
     overrideValuesName?: string;
 }) =>

--- a/packages/ui/src/data/sqon/utils.ts
+++ b/packages/ui/src/data/sqon/utils.ts
@@ -361,7 +361,7 @@ export const deepMergeFieldInActiveQuery = ({
     value: Array<string | number | boolean>;
     index?: string;
     merge_strategy?: MERGE_VALUES_STRATEGIES;
-    operator?: TermOperators;
+    operator?: TermOperators | RangeOperators;
     overrideValuesName?: string;
 }) => {
     let newSqon;


### PR DESCRIPTION
# FEATURE

- closes #[393](https://d3b.atlassian.net/browse/SKFP-393)

## Description

KF portal's `Age at diagnosis` graph needs to trigger a graphlql request with RangeOperator
![image](https://user-images.githubusercontent.com/65532894/197046424-3c4303f7-4f8f-443d-be45-8a4febee84ef.png)
![image](https://user-images.githubusercontent.com/65532894/197046528-ed18f4b0-d349-4ae4-ad0a-7a3ea7b209ff.png)


[BONUS]
I updated the installation documentation

## Screenshot (Before and After)

https://user-images.githubusercontent.com/65532894/197047097-fb0e7bdb-9922-4759-99bd-86da0f0adeb0.mp4



