### PR TITLE
feat: SKFP-283 add tooltips to facet header

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -28,6 +28,8 @@ Steps to develop or debug the libraries in a real project
 
 #### Duplicate React
 
+##### TsConfig solution
+
 Linking the library will add the packages twice in the bundle, which could create some issues with `react` and `react-dom`. It's important to add an alias to use the host modules.
 
 e.g. in tsconfig | please refer to [clin-portal-ui](https://github.com/Ferlab-Ste-Justine/clin-portal-ui) for a working example.
@@ -44,7 +46,9 @@ e.g. in tsconfig | please refer to [clin-portal-ui](https://github.com/Ferlab-St
 }
 ```
 
-This problem can also come up when you use npm link or an equivalent. In that case, your bundler might “see” two Reacts — one in application folder and one in your library folder. Assuming myapp and mylib are sibling folders, one possible fix is to run npm link ../myapp/node_modules/react from mylib. This should make the library use the application’s React copy.
+##### Npm link solution
+
+This problem can also come up when you use npm link or an equivalent. In that case, your bundler might “see” two Reacts — one in application folder and one in your library folder. Assuming myapp and mylib are sibling folders, one possible fix is to run `npm link ../myapp/node_modules/react` from mylib. This should make the library use the application’s React copy.
 
 ### Storybook
 
@@ -76,7 +80,7 @@ To publish a new release once a PR as been validated and merged
 4. On master Update package.json version
 5. Push the new version
 6. Create a tag to the new version `git tag ui@[semantic version]`
-  e.g.
+   e.g.
     > git tab ui@4.4.1
     > git push --tags
 7. Login to npm

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.4.1",
+    "version": "4.5.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/FilterContainer.tsx
+++ b/packages/ui/src/components/filters/FilterContainer.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { SearchOutlined } from '@ant-design/icons';
+import { InfoCircleOutlined, SearchOutlined } from '@ant-design/icons';
+import { Tooltip } from 'antd';
 import cx from 'classnames';
+
 import StackLayout from '../../layout/StackLayout';
-import FilterSelector from './FilterSelector';
+import Collapse, { CollapsePanel, TCollapseProps } from '../Collapse';
+
 import CheckedIcon from './icons/CheckedIcon';
+import FilterSelector from './FilterSelector';
 import {
     IDictionary,
     IFilter,
@@ -13,7 +17,6 @@ import {
     onSearchVisibleChange,
     VisualType,
 } from './types';
-import Collapse, { CollapsePanel, TCollapseProps } from '../Collapse';
 
 import styles from '@ferlab/style/components/filters/FilterContainer.module.scss';
 
@@ -34,13 +37,27 @@ type FilterContainerProps = {
 
 type FilterContainerHeaderProps = {
     title: string | React.ReactNode;
+    tooltip?: string;
     hasFilters?: boolean;
 };
 
-const FilterContainerHeader: React.FC<FilterContainerHeaderProps> = ({ title, hasFilters = false }) => (
+const FilterContainerHeader: React.FC<FilterContainerHeaderProps> = ({ hasFilters = false, title, tooltip }) => (
     <StackLayout className={styles.filtersContainerHeader}>
         <div className={styles.titleContainer}>
-            <span className={styles.title}>{title}</span>
+            {tooltip ? (
+                <Tooltip title={tooltip}>
+                    <span
+                        className={styles.title}
+                        style={{
+                            borderBottom: '1px dotted',
+                        }}
+                    >
+                        {title}
+                    </span>
+                </Tooltip>
+            ) : (
+                <span className={styles.title}>{title}</span>
+            )}
             {hasFilters && <CheckedIcon className={styles.hasFilterIcon}></CheckedIcon>}
         </div>
     </StackLayout>
@@ -80,9 +97,9 @@ const FilterContainer = ({
         <div className={cx(styles.filterContainer, className)}>
             <Collapse
                 {...collapseProps}
-                defaultActiveKey={collapseOpen ? filterGroup.field : undefined}
                 activeKey={collapseOpen ? filterGroup.field : undefined}
                 className={cx(styles.filterContainerCollapse, collapseProps?.className)}
+                defaultActiveKey={collapseOpen ? filterGroup.field : undefined}
                 onChange={(panels) => {
                     if (onIsOpenChange) onIsOpenChange(panels.length !== 0);
                     setCollapseOpen(panels.length !== 0);
@@ -91,8 +108,6 @@ const FilterContainer = ({
             >
                 <CollapsePanel
                     className={styles.filterContainerContent}
-                    header={<FilterContainerHeader title={filterGroup.title} />}
-                    key={filterGroup.field}
                     extra={
                         hasSearchEnabled() && collapseOpen
                             ? [
@@ -108,6 +123,8 @@ const FilterContainer = ({
                               ]
                             : []
                     }
+                    header={<FilterContainerHeader title={filterGroup.title} tooltip={filterGroup.headerTooltip} />}
+                    key={filterGroup.field}
                 >
                     {customContent ? (
                         customContent

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+
 import { RangeOperators, TermOperators } from '../../data/sqon/operators';
 
 export type onChangeType = (fg: IFilterGroup, f: IFilter[]) => void;
@@ -63,6 +64,7 @@ export interface IFilterGroup<T extends TFilterGroupConfig = any> {
     config?: T;
     title: ReactNode;
     type: VisualType;
+    headerTooltip?: string;
 }
 
 export interface IFilterCount {
@@ -92,6 +94,10 @@ export interface IDictionary {
     checkBox?: ICheckBox;
     range?: IRange;
     operators?: IOperators;
+}
+
+export interface IFacetDictionary {
+    [key: string]: any;
 }
 
 export interface IActions {
@@ -128,4 +134,20 @@ export interface IOperators {
     allOf?: ReactNode;
     anyOf?: ReactNode;
     noneOf?: ReactNode;
+}
+
+export type TExtendedMapping = {
+    active: boolean;
+    displayName: string;
+    isArray: boolean;
+    type: string;
+    field: string;
+    rangeStep?: number;
+};
+
+export interface IRangeAggs {
+    stats: {
+        max: number;
+        min: number;
+    };
 }

--- a/packages/ui/src/data/filters/Range.ts
+++ b/packages/ui/src/data/filters/Range.ts
@@ -4,6 +4,7 @@ import {
     IFilterGroup,
     IFilterRange,
     IFilterText,
+    IRangeAggs,
     VisualType,
 } from '../../components/filters/types';
 import { BooleanOperators, FieldOperators, RangeOperators, TermOperators } from '../sqon/operators';
@@ -77,3 +78,5 @@ export const getRangeSelection = (filters: ISyntheticSqon, filterGroup: IFilterG
 
     return rangeSelection;
 };
+
+export const isRangeAgg = (obj: IRangeAggs) => !!obj.stats;

--- a/storybook/stories/Components/Filters/FilterContainer.stories.tsx
+++ b/storybook/stories/Components/Filters/FilterContainer.stories.tsx
@@ -1,35 +1,55 @@
 import React from "react";
-import {Meta, Story} from '@storybook/react/types-6-0';
-import {TermFilterProps} from "@ferlab/ui/components/filters/CheckboxFilter";
-import {IFilter, IFilterCount, IFilterGroup, IFilterTextInputConfig, onChangeType, VisualType} from "@ferlab/ui/components/filters/types";
-import {filters} from "./data";
+import { Meta, Story } from "@storybook/react/types-6-0";
+import { TermFilterProps } from "@ferlab/ui/components/filters/CheckboxFilter";
+import {
+    IFilter,
+    IFilterCount,
+    IFilterGroup,
+    onChangeType,
+    VisualType,
+} from "@ferlab/ui/components/filters/types";
+import { filters } from "./data";
 import FilterContainer from "@ferlab/ui/components/filters/FilterContainer";
 
 export default {
     title: "@ferlab/Components/Filters/FilterContainer",
     component: FilterContainer,
-    decorators: [(Story) =>
-        <>
-            <div className={'story_container'} style={{display: 'inline-grid'}}><Story/></div>
-        </>],
+    decorators: [
+        (Story) => (
+            <>
+                <div
+                    className={"story_container"}
+                    style={{ display: "inline-grid" }}
+                >
+                    <Story />
+                </div>
+            </>
+        ),
+    ],
     argTypes: {
         className: {
-            control: 'string',
+            control: "string",
         },
         children: {
-            control: 'object',
+            control: "object",
         },
     },
 } as Meta;
 
-const FilterContainerStory = ({title, maxShowing, filterGroup, onChange, ...props}: {
-    title: string,
-    maxShowing: number,
-    filterGroup: IFilterGroup,
-    onChange: onChangeType,
+const FilterContainerStory = ({
+    title,
+    maxShowing,
+    filterGroup,
+    onChange,
+    ...props
+}: {
+    title: string;
+    maxShowing: number;
+    filterGroup: IFilterGroup;
+    onChange: onChangeType;
     searchInputVisible: boolean;
     filters: IFilter<IFilterCount>[];
-    props: Story<TermFilterProps>
+    props: Story<TermFilterProps>;
 }) => (
     <>
         <h3>{title}</h3>
@@ -37,23 +57,29 @@ const FilterContainerStory = ({title, maxShowing, filterGroup, onChange, ...prop
             filterGroup={filterGroup}
             maxShowing={maxShowing}
             onChange={onChange}
-
             {...props}
         />
     </>
 );
 
 const filterGroupTerm: IFilterGroup = {
-    field: 'this.field',
-    title: 'title_filter_group',
+    field: "this.field",
+    title: "title_filter_group",
     type: VisualType.Checkbox,
-}
+};
 
-const onChangeTypeStory: onChangeType = () => null
+const filterGroupTermTooltip: IFilterGroup = {
+    field: "this.field",
+    title: "title_filter_group",
+    type: VisualType.Checkbox,
+    headerTooltip: "This is a tooltip",
+};
+
+const onChangeTypeStory: onChangeType = () => null;
 
 export const TermFilterContainer = FilterContainerStory.bind({});
 TermFilterContainer.args = {
-    title: 'Filter Container Checkbox',
+    title: "Filter Container Checkbox",
     maxShowing: 6,
     filterGroup: filterGroupTerm,
     onChangeType: onChangeTypeStory(filterGroupTerm, filters),
@@ -63,11 +89,23 @@ TermFilterContainer.args = {
 
 export const TermFilterContainerWithFilter = FilterContainerStory.bind({});
 TermFilterContainerWithFilter.args = {
-    title: 'Filter Container Checkbox With Filter',
+    title: "Filter Container Checkbox With Filter",
     maxShowing: 6,
     filterGroup: filterGroupTerm,
     onChangeType: onChangeTypeStory(filterGroupTerm, filters),
     hasSearchInput: true,
     filters: filters,
-    selectedFilters: [{"data":{"count":9,"key":"Nine"},"name":"nine","id":"id_nine"}]
+    selectedFilters: [
+        { data: { count: 9, key: "Nine" }, name: "nine", id: "id_nine" },
+    ],
+};
+
+export const TooltipsFilterContainer = FilterContainerStory.bind({});
+TooltipsFilterContainer.args = {
+    title: "Filter Container With Tooltip",
+    maxShowing: 6,
+    filterGroup: filterGroupTermTooltip,
+    onChangeType: onChangeTypeStory(filterGroupTerm, filters),
+    hasSearchInput: true,
+    filters: filters,
 };


### PR DESCRIPTION
# FEATURE

- closes #[283](https://d3b.atlassian.net/browse/SKFP-283)

## Description

Facets should be able to display a tooltips when needed

Acceptance Criterias

1. Tooltips can be defined when passing FilterInfo to ferlab-ui

```javascript
      {
        title: intl.get('facets.genePanels'),
        facets: [
          'genes__hpo__hpo_term_label',
          'genes__orphanet__panel',
          'genes__omim__name',
          'genes__ddd__disease_name',
          'genes__cosmic__tumour_types_germline',
        ],
        tooltips: [
          'genes__hpo__hpo_term_label',
          'genes__omim__name',
          'genes__ddd__disease_name',
          'genes__cosmic__tumour_types_germline',
        ],
      },
```
2. Add a facets dictionary in your project. If your don't want to use the display_name property, you can setup a custom tooltips text inside the tooltips section

```javascript
export const getFacetsDictionary = () => ({
  genes: {
    cosmic: {
      tumour_types_germline: 'COSMIC',
    },
  },
  tooltips: {
    genes: {
      cosmic: {
        tumour_types_germline: 'Catalogue Of Somatic Mutations In Cancer',
      },
    },
  },
});
```

3. `getFilterGroup` has also been moved to `ferlab-ui`


## Validation de Qualité

- [x] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [x] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
![Screenshot_20221026_092149](https://user-images.githubusercontent.com/65532894/198037324-9779159c-ae6d-458d-8486-c72d7071d24e.png)


### After
![Peek 2022-10-26 09-22](https://user-images.githubusercontent.com/65532894/198037353-b7f443a1-b01f-4c5c-b780-8305490df390.gif)

### Storybook
![image](https://user-images.githubusercontent.com/65532894/198098607-2c01e52f-ef47-4b14-bca7-be379aa0f737.png)


## Mention
@luclemo @kstonge

