### PR TITLE
feat: FLUI-8 adjust collaps header title size

### DIFF
--- a/packages/style/components/collapse/Collapse.module.scss
+++ b/packages/style/components/collapse/Collapse.module.scss
@@ -45,6 +45,15 @@ $prefix-ant-collapse: "ant-collapse";
     > :global(.#{$prefix-ant-collapse}-item) {
       > :global(.#{$prefix-ant-collapse}-header) {
         padding: 16px 24px;
+        font-size: 16px;
+      }
+    }
+  }
+
+  &.default {
+    > :global(.#{$prefix-ant-collapse}-item) {
+      > :global(.#{$prefix-ant-collapse}-header) {
+        font-size: 16px;
       }
     }
   }
@@ -53,6 +62,7 @@ $prefix-ant-collapse: "ant-collapse";
     > :global(.#{$prefix-ant-collapse}-item) {
       > :global(.#{$prefix-ant-collapse}-header) {
         padding: 5.5px 16px;
+        font-size: 14px;
 
         :global(.#{$prefix-ant-collapse}-arrow) {
           padding-top: 5.5px;

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/style",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.5.0",
+    "version": "4.5.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Collapse/index.tsx
+++ b/packages/ui/src/components/Collapse/index.tsx
@@ -1,19 +1,14 @@
-import { Collapse as AntCollapse, CollapseProps, CollapsePanelProps } from 'antd';
-import cx from 'classnames';
 import React from 'react';
-import {
-    CaretDownOutlined,
-    CaretRightOutlined,
-    DownOutlined,
-    RightOutlined,
-} from '@ant-design/icons';
+import { CaretDownOutlined, CaretRightOutlined, DownOutlined, RightOutlined } from '@ant-design/icons';
+import { Collapse as AntCollapse, CollapsePanelProps, CollapseProps } from 'antd';
+import cx from 'classnames';
 import { isUndefined } from 'lodash';
 
 import styles from '@ferlab/style/components/collapse/Collapse.module.scss';
 
 export type TCollapseProps = CollapseProps & {
     children?: React.ReactNode;
-    size?: 'large' | 'default' | 'small';
+    size?: 'large' | 'default' | 'small';
     theme?: 'shade' | 'light';
     arrowIcon?: 'caretOutlined' | 'caretFilled';
     headerBorderOnly?: boolean;
@@ -24,14 +19,22 @@ export type TCollapsePanelProps = CollapsePanelProps & {
 };
 
 const Collapse = ({
-    size = 'default',
-    theme = 'light',
     arrowIcon = 'caretOutlined',
     headerBorderOnly = false,
+    size = 'default',
+    theme = 'light',
     ...rest
 }: TCollapseProps) => (
     <AntCollapse
         {...rest}
+        bordered={isUndefined(rest.bordered) ? !headerBorderOnly : rest.bordered && !headerBorderOnly}
+        className={cx(
+            styles.fuiCollapse,
+            styles[size],
+            styles[theme],
+            headerBorderOnly ? styles.headerBorderOnly : '',
+            rest.className,
+        )}
         expandIcon={
             rest.expandIcon ??
             (({ isActive }) =>
@@ -47,14 +50,6 @@ const Collapse = ({
                     <CaretRightOutlined />
                 ))
         }
-        bordered={isUndefined(rest.bordered) ? !headerBorderOnly : rest.bordered && !headerBorderOnly}
-        className={cx(
-            styles.fuiCollapse,
-            styles[size],
-            styles[theme],
-            headerBorderOnly ? styles.headerBorderOnly : '',
-            rest.className,
-        )}
     />
 );
 


### PR DESCRIPTION
# [Fix] [FLUI-8 adjust collaps header title size]

- closes #3242

## Description

FLUI-8 adjust collaps header title size
https://ferlab-crsj.atlassian.net/browse/FLUI-8

Acceptance Criterias

header size 16px for default and large 

## Validation de Qualité


- [X] Validation du design avec design figma (dev)
- [X] QA - Validation des critères de succès (via screenshot)
- [X] Design/UI - Validation du respect du design/theme

## Screenshot
### Before

### After
<img width="641" alt="image" src="https://user-images.githubusercontent.com/15524246/198709859-795c302d-6844-4f9c-b8ce-90b899b8d526.png">


## Mention
@luclemo @kstonge

