### PR TITLE
✨feat(variant): SKFP-522 add afterSearch, refact code

### DIFF
--- a/packages/style/components/protable/Pagination.module.scss
+++ b/packages/style/components/protable/Pagination.module.scss
@@ -1,0 +1,5 @@
+.pagination {
+  margin: 16px 0 4px;
+  justify-content: end;
+  width: 100%;
+}

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/style",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.5.4",
+    "version": "4.6.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Pagination/constants.ts
+++ b/packages/ui/src/components/ProTable/Pagination/constants.ts
@@ -1,0 +1,6 @@
+export enum PaginationViewPerQuery {
+    Ten = 10,
+    Twenty = 20,
+    Fifty = 50,
+    OneHundred = 100,
+}

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -1,0 +1,113 @@
+import React, { ReactElement } from 'react';
+import { DoubleLeftOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { Button, Select, Space } from 'antd';
+
+import { IPaginationProps } from '../types';
+import { reverseSortDirection } from '../utils';
+
+import { PaginationViewPerQuery } from './constants';
+import { getPaginationOptions } from './utils';
+
+import styles from '@ferlab/style/components/protable/Pagination.module.scss';
+
+const iconSize = 11;
+
+const Pagination = ({
+    current,
+    defaultViewPerQuery,
+    dictionary,
+    onChange,
+    onPageChange,
+    onShowSizeChange,
+    queryConfig,
+    searchAfter,
+    setQueryConfig,
+    total,
+}: IPaginationProps): ReactElement => {
+    const isDisabled =
+        queryConfig.searchAfter === undefined ||
+        total === 0 ||
+        queryConfig.firstPageFlag?.toString() === searchAfter?.tail?.toString();
+
+    return (
+        <Space className={styles.pagination}>
+            <Select
+                defaultValue={defaultViewPerQuery}
+                onSelect={(viewPerQuery: PaginationViewPerQuery) => {
+                    setQueryConfig({
+                        ...queryConfig,
+                        size: viewPerQuery,
+                        sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
+                    });
+                    onShowSizeChange();
+                }}
+                options={getPaginationOptions(dictionary?.pagination?.view || '{value} / view')}
+                size="small"
+            />
+
+            <Button
+                disabled={isDisabled}
+                onClick={() => {
+                    setQueryConfig({
+                        ...queryConfig,
+                        operations: undefined,
+                        searchAfter: undefined,
+                        sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
+                    });
+
+                    onPageChange();
+                    onChange(1, queryConfig.size);
+                }}
+                size="small"
+                type="text"
+            >
+                <DoubleLeftOutlined height={iconSize} />
+                {dictionary?.pagination?.first || 'First'}
+            </Button>
+            <Button
+                disabled={isDisabled}
+                onClick={() => {
+                    setQueryConfig({
+                        ...queryConfig,
+                        operations: {
+                            next: false,
+                            previous: true,
+                        },
+                        searchAfter: searchAfter?.head,
+                        sort: queryConfig.operations?.next ? reverseSortDirection(queryConfig) : queryConfig.sort,
+                    });
+
+                    onPageChange();
+                    onChange(current - 1, queryConfig.size);
+                }}
+                size="small"
+            >
+                <LeftOutlined height={iconSize} />
+                {dictionary?.pagination?.previous || 'Prev.'}
+            </Button>
+            <Button
+                disabled={total === 0}
+                onClick={() => {
+                    setQueryConfig({
+                        ...queryConfig,
+                        operations: {
+                            next: true,
+                            previous: false,
+                        },
+                        searchAfter: searchAfter?.tail,
+                        sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
+                    });
+
+                    onPageChange();
+                    onChange(current + 1, queryConfig.size);
+                }}
+                size="small"
+            >
+                {dictionary?.pagination?.next || 'Next'}
+                <RightOutlined height={iconSize} />
+            </Button>
+        </Space>
+    );
+};
+
+export default Pagination;

--- a/packages/ui/src/components/ProTable/Pagination/utils.ts
+++ b/packages/ui/src/components/ProTable/Pagination/utils.ts
@@ -1,0 +1,20 @@
+import { PaginationViewPerQuery } from './constants';
+
+export const getPaginationOptions = (labelFormat: string) => [
+    {
+        label: labelFormat.replace('{value}', PaginationViewPerQuery.Ten.toString()),
+        value: PaginationViewPerQuery.Ten,
+    },
+    {
+        label: labelFormat.replace('{value}', PaginationViewPerQuery.Twenty.toString()),
+        value: PaginationViewPerQuery.Twenty,
+    },
+    {
+        label: labelFormat.replace('{value}', PaginationViewPerQuery.Fifty.toString()),
+        value: PaginationViewPerQuery.Fifty,
+    },
+    {
+        label: labelFormat.replace('{value}', PaginationViewPerQuery.OneHundred.toString()),
+        value: PaginationViewPerQuery.OneHundred,
+    },
+];

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -1,6 +1,28 @@
-import { TableProps } from 'antd';
-import { ColumnType } from 'antd/lib/table';
 import React, { ReactNode } from 'react';
+import { TableProps } from 'antd';
+import { ColumnType, TablePaginationConfig } from 'antd/lib/table';
+
+import { IQueryConfig, ISearchAfter, TQueryConfigCb } from '../../graphql/types';
+
+import { PaginationViewPerQuery } from './Pagination/constants';
+
+export enum PaginationDirection {
+    Previous = 'previous',
+    Next = 'next',
+}
+
+export interface IPaginationProps {
+    current: number;
+    setQueryConfig: TQueryConfigCb;
+    queryConfig: IQueryConfig;
+    defaultViewPerQuery?: PaginationViewPerQuery;
+    searchAfter?: ISearchAfter;
+    onPageChange: () => void;
+    onShowSizeChange: () => void;
+    onChange: (page: number, pageSize: number) => void;
+    total: number;
+    dictionary?: IProTableDictionary;
+}
 
 export interface IProTableDictionary {
     itemCount?: {
@@ -21,6 +43,12 @@ export interface IProTableDictionary {
             columns: React.ReactNode;
         };
     };
+    pagination?: {
+        first: string;
+        previous: string;
+        next: string;
+        view: string;
+    };
     numberFormat?: (value: number) => React.ReactNode;
 }
 
@@ -33,11 +61,12 @@ export interface ProColumnType<T = any> extends ColumnType<T> {
     defaultHidden?: boolean;
 }
 
-export type TProTableProps<RecordType> = Omit<TableProps<RecordType>, 'columns'> & {
+export type TProTableProps<RecordType> = Omit<TableProps<RecordType>, 'columns' | 'pagination'> & {
     tableId: string;
     headerConfig: THeaderConfig<RecordType>;
     wrapperClassName?: string;
     columns: ProColumnType<RecordType>[];
+    pagination?: IPaginationProps | TablePaginationConfig;
     initialColumnState?: TColumnStates;
     initialSelectedKey?: any[];
     dictionary?: IProTableDictionary;

--- a/packages/ui/src/components/ProTable/utils.ts
+++ b/packages/ui/src/components/ProTable/utils.ts
@@ -1,0 +1,25 @@
+import { SortDirection } from '../../graphql/constants';
+import { IQueryConfig, ISort } from '../../graphql/types';
+
+type TTieBreaker = {
+    sort: ISort[];
+    defaultSort: ISort[];
+    field: string;
+    order: SortDirection;
+};
+export const tieBreaker = ({ field, defaultSort, order = SortDirection.Asc, sort }: TTieBreaker): ISort[] => {
+    const resultSort = sort.length > 0 ? sort : defaultSort;
+    return resultSort.some((e) => e.field === field) ? resultSort : ([...resultSort, { field, order }] as ISort[]);
+};
+
+export const reverseSortDirection = (queryConfig: IQueryConfig): ISort[] =>
+    queryConfig.sort.map((sort: ISort) => {
+        if (!sort.order) {
+            return sort;
+        }
+
+        return {
+            ...sort,
+            order: sort.order === SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc,
+        };
+    });

--- a/packages/ui/src/components/QueryBuilder/types.ts
+++ b/packages/ui/src/components/QueryBuilder/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ISqonGroupFilter, ISyntheticSqon, IValueFilter } from '../../data/sqon/types';
 import { TCollapseProps } from '../Collapse';
 

--- a/packages/ui/src/graphql/constants.ts
+++ b/packages/ui/src/graphql/constants.ts
@@ -1,0 +1,4 @@
+export enum SortDirection {
+    Asc = 'asc',
+    Desc = 'desc',
+}

--- a/packages/ui/src/graphql/types.ts
+++ b/packages/ui/src/graphql/types.ts
@@ -1,0 +1,106 @@
+import { SortOrder } from 'antd/lib/table/interface';
+
+import { TExtendedMapping } from '../components/filters/types';
+import { ISyntheticSqon } from '../data/sqon/types';
+
+import { SortDirection } from './constants';
+
+export interface IArrangerNodeData {
+    id: string;
+    cid?: string;
+    key?: string;
+}
+
+export type TAggregationBuckets = {
+    buckets: [
+        {
+            key: string;
+            doc_count: number;
+        },
+    ];
+    stats: string;
+};
+
+export type TRawAggregation = {
+    data: {
+        [key: string]: {
+            aggregations: TAggregations;
+        };
+    };
+};
+
+export type TAggregations = Record<string, TAggregationBuckets>;
+
+export interface IGqlResults<DataT> {
+    data: DataT[];
+    aggregations: TAggregations;
+    loading: boolean;
+    total: number;
+}
+
+// Recursive type that can represent nested query
+export interface IArrangerResultsTree<T extends IArrangerNodeData> {
+    hits: IArrangerHits<T>;
+}
+
+export interface IArrangerHits<T extends IArrangerNodeData> {
+    total?: number;
+    edges: IArrangerEdge<T>[];
+}
+
+export type IArrangerEdge<T extends IArrangerNodeData> = {
+    node: T;
+    searchAfter?: any[];
+};
+
+export interface IExtendedMappingResults {
+    loading: boolean;
+    data: TExtendedMapping[];
+}
+
+export interface ISearchAfter {
+    head?: any[];
+    tail?: any[];
+}
+
+export interface IQueryResults<T> {
+    data: T;
+    loading: boolean;
+    total: number;
+    searchAfter?: ISearchAfter;
+}
+
+export type IQueryVariable = {
+    sqon?: ISyntheticSqon;
+    first?: number;
+    offset?: number;
+    sort?: ISort[];
+    pageSize?: number;
+    searchAfter?: any[];
+};
+
+export interface ISort {
+    field: string;
+    order: SortDirection;
+}
+
+export interface IQueryOperationsConfig {
+    previous?: boolean;
+    next?: boolean;
+}
+
+export interface IQueryConfig {
+    pageIndex: number;
+    size: number;
+    sort: ISort[];
+    searchAfter?: any[];
+    firstPageFlag?: any[];
+    operations?: IQueryOperationsConfig;
+}
+
+export type TPagingConfig = {
+    index: number;
+    size: number;
+};
+
+export type TQueryConfigCb = (config: IQueryConfig) => void;

--- a/packages/ui/src/graphql/utils.ts
+++ b/packages/ui/src/graphql/utils.ts
@@ -1,0 +1,23 @@
+import { IArrangerEdge, IArrangerNodeData, IQueryOperationsConfig, ISearchAfter } from './types';
+
+export const hydrateResults = <resultType extends IArrangerNodeData>(
+    results: IArrangerEdge<resultType>[],
+    reverse = false,
+): resultType[] => {
+    const hydratedResults = results.map(
+        (edge: IArrangerEdge<resultType>, index): resultType => ({
+            ...edge.node,
+            key: edge.node?.id || index,
+        }),
+    );
+
+    return reverse ? hydratedResults.reverse() : hydratedResults;
+};
+
+export const computeSearchAfter = <resultType extends IArrangerNodeData>(
+    result: IArrangerEdge<resultType>[],
+    operations?: IQueryOperationsConfig,
+): ISearchAfter => ({
+    head: operations?.previous ? result[result.length - 1]?.searchAfter : result[0]?.searchAfter,
+    tail: operations?.previous ? result[0]?.searchAfter : result[result.length - 1]?.searchAfter,
+});

--- a/storybook/stories/Components/Tables/ProTable/ProTable.stories.tsx
+++ b/storybook/stories/Components/Tables/ProTable/ProTable.stories.tsx
@@ -1,4 +1,5 @@
 import ProTable from "@ferlab/ui/components/ProTable";
+import { PaginationViewPerQuery } from "@ferlab/ui/components/ProTable/Pagination/constants";
 import { TProTableProps } from "@ferlab/ui/components/ProTable/types";
 import { Meta } from "@storybook/react/types-6-0";
 import React from "react";
@@ -49,7 +50,7 @@ BasicTable.args = {
             title: "Column 3",
             dataIndex: "column_three",
             tooltip: "This is Column 3",
-            iconTitle: <AiOutlineUsergroupAdd />
+            iconTitle: <AiOutlineUsergroupAdd />,
         },
         {
             key: "column_four",
@@ -92,6 +93,100 @@ BasicTable.args = {
     pagination: {
         pageSize: 2,
         defaultPageSize: 2,
+        total: 4,
+    },
+    headerConfig: {
+        marginBtm: 12,
+        extra: [<a>Extra Actions</a>],
+        enableColumnSort: true,
+        itemCount: {
+            pageIndex: 1,
+            pageSize: 2,
+            total: 4,
+        },
+        onClearSelection: () => {
+            console.log("Clicked on clear selection");
+        },
+        onColumnStateChange: (state: any) => {
+            console.log(state);
+        },
+    },
+};
+
+export const AfterSearchTable = ProTableStory.bind({});
+AfterSearchTable.args = {
+    columns: [
+        {
+            key: "column_one",
+            title: "Column 1",
+            dataIndex: "column_one",
+        },
+        {
+            key: "column_two",
+            title: "Column 2",
+            dataIndex: "column_two",
+        },
+        {
+            key: "column_three",
+            title: "Column 3",
+            dataIndex: "column_three",
+            tooltip: "This is Column 3",
+            iconTitle: <AiOutlineUsergroupAdd />,
+        },
+        {
+            key: "column_four",
+            title: "Column 4",
+            dataIndex: "column_four",
+            defaultHidden: true,
+        },
+    ],
+    dataSource: [
+        {
+            key: "1",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+        {
+            key: "2",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+        {
+            key: "3",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+        {
+            key: "4",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+    ],
+    tableId: "test-table",
+    pagination: {
+        current: 1,
+        queryConfig: {
+            firstPageFlag: undefined,
+            operations: undefined,
+            pageIndex: 0,
+            searchAfter: undefined,
+            size: 10,
+            sort: [{ field: "column_one", order: "desc" }],
+        },
+        onChange: (page: number, _) => {},
+        searchAfter: {
+            head: [],
+            tail: [],
+        },
+        defaultViewPerQuery: PaginationViewPerQuery.Ten,
         total: 4,
     },
     headerConfig: {


### PR DESCRIPTION
# FEATURE

- closes #[522](https://d3b.atlassian.net/browse/SKFP-522)

## Description

1. Ajout de la gestion du `SearchAfter`
2. Export des types communs côté ferlab-ui concernant graphql

À lire
[Guide de migration](https://www.notion.so/ferlab/Search-After-guide-de-migration-Front-End-8a0cd7ed40984f219f0174d64404b09b)
[Kids First PR](https://github.com/kids-first/kf-portal-ui/pull/3575)

À noter que l'ancienne pagination devrait toujours être compatible.

Acceptance Criterias

## Validation de Qualité

- [x] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [x] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/65532894/201144273-ff159d38-0a6c-40e8-ac8e-e4a9be974bce.png)
![image](https://user-images.githubusercontent.com/65532894/201145018-9ccb1577-e6e5-401b-a691-c19dfabd3f09.png)


### After
![image](https://user-images.githubusercontent.com/65532894/201144410-0cb67e6e-a390-4618-bd8d-eaba3d733c98.png)
![image](https://user-images.githubusercontent.com/65532894/201144937-6091cf62-3208-41c2-97bb-14ac9c79e79d.png)

