### PR TITLE
🐛fix(pagination): SKFP-522 fix next button disable behaviour

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.6.1",
+    "version": "4.6.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -86,7 +86,7 @@ const Pagination = ({
                 {dictionary?.pagination?.previous || 'Prev.'}
             </Button>
             <Button
-                disabled={total === 0}
+                disabled={total === 0 || total < queryConfig.size}
                 onClick={() => {
                     setQueryConfig({
                         ...queryConfig,

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -264,6 +264,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                     onShowSizeChange={() => {
                         handleOnSelectRowsChange([], []);
                     }}
+                    total={tableProps.dataSource?.length || headerConfig.itemCount?.total}
                 />
             )}
         </Space>


### PR DESCRIPTION
# BUG 

- closes #[522](https://d3b.atlassian.net/browse/SKFP-522)

## Description

Notion updated : https://www.notion.so/ferlab/Search-After-guide-de-migration-Front-End-8a0cd7ed40984f219f0174d64404b09b

Acceptance Criterias
## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [ ] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot

1. Désactiver le bouton Next quand il n’y a qu’une seule page d’affichée pour éviter d’afficher une page vide en cliquant sur Next.
![Peek 2022-11-17 15-27](https://user-images.githubusercontent.com/65532894/202555553-33fe1b57-6d06-4a8f-9b83-050b3c2e778b.gif)
![Screenshot_20221117_152830](https://user-images.githubusercontent.com/65532894/202555622-cd62b94a-79fc-47c7-b6ed-17f471430736.png)


2. Désactiver le bouton Next lorsqu’il n’y a aucun résultat. Note: Cliquer sur Next ne fait rien ici.
![Screenshot_20221117_153025](https://user-images.githubusercontent.com/65532894/202555385-788cadd7-bb46-4645-9f8f-c2445af67c08.png)

3. Retourner à la première page au changement de requête.
![Peek 2022-11-17 15-44](https://user-images.githubusercontent.com/65532894/202555969-8f7635ba-a28b-4ae2-b077-512b70eb5a4e.gif)

4. Il n’est pas possible d’afficher les résultats au delà de 10K éléments.

https://user-images.githubusercontent.com/65532894/202556063-99313a42-06f6-480a-8447-1ddbb47c4377.mp4



## Mention
@kstonge

