### PR TITLE
fix: FLUI-18 no checkbox for active query

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.6.1",
+    "version": "4.6.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "4.1.2",
+            "version": "4.6.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.6.2",
+    "version": "4.6.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
# BUG

- closes https://ferlab-crsj.atlassian.net/browse/CLIN-1526

## Description

Gestion des erreurs qui apparaissent lors de la création des requêtes de variants. 
Cette story est sensée répondre à cette problématique: 

Plantage lors d’une combinaison de requêtes :

QUI : une utilisatrice de CLIN fait des requêtes combinées tombe de temps en temps sur une erreur 500. Une fois au 3 jours ouvrables. Quand ça arrive il est impossible d’ouvrir la page variant.

[ ] Désactivé la checkbox de la query en cours.

## Validation de Qualité

- [x] Validation du design avec design figma (dev)
- [ ] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
<img width="1217" alt="Screenshot 2022-11-18 at 4 16 45 PM" src="https://user-images.githubusercontent.com/98903/203081796-533f2378-0b3b-49d8-8044-ca2e0bc0fc86.png">
![Screenshot 2022-11-21 at 9 43 24 AM](https://user-images.githubusercontent.com/98903/203085147-90787a36-6a9b-4477-8464-a42b9a82d6ba.png)

### After
<img width="1217" alt="Screenshot 2022-11-18 at 4 16 45 PM" src="https://user-images.githubusercontent.com/98903/203082904-4a3e23d3-73bd-4481-9767-ee7d2232c532.png">

## Mention
@luclemo @kstonge

