### PR TITLE
fix: CQDG-110 rerender when prop change

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 4.6.4 | 2022-11-22
+- Fix: CQDG-110 add useEffect to SortableGrid to rerender when `items` prop change
+
 ### 4.6.1 | 2022-11-16
 - Fix: FLUI-17 remove field value from combined query remove all ref pills
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.6.3",
+    "version": "4.6.4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/SortableGrid/index.tsx
+++ b/packages/ui/src/layout/SortableGrid/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useState } from 'react';
 import {
     closestCenter,
@@ -47,6 +47,12 @@ const SortableGrid = ({ gutter, items, onReorder }: OwnProps) => {
             });
         }
     };
+
+    useEffect(() => {
+        if (items) {
+            setCurrentItems(items);
+        }
+    }, [items]);
 
     return (
         <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd} sensors={sensors}>


### PR DESCRIPTION
# FIX rerender SortableGrid when prop `items` change

https://ferlab-crsj.atlassian.net/browse/CQDG-110

## Description

```const [currentItems, setCurrentItems] = useState(items);```
this useState blocks `items` so the translations are never changed
useEffect is used to re-`setCurrentItems` when `items` props change





