### PR TITLE
🐛fix(filter): fix an issue where an edited filter would replace the c…

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.7.2",
+    "version": "4.7.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/Header/Tools/ManageFiltersModal.tsx
+++ b/packages/ui/src/components/QueryBuilder/Header/Tools/ManageFiltersModal.tsx
@@ -1,11 +1,13 @@
+import React, { Fragment, useContext, useState } from 'react';
 import { ConfigProvider, List, Modal } from 'antd';
 import { formatDistance } from 'date-fns';
 import enUS from 'date-fns/locale/en-US';
 import frCa from 'date-fns/locale/fr-CA';
-import React, { Fragment, useContext, useState } from 'react';
+
 import ListItemWithActions from '../../../List/ListItemWithActions';
 import { QueryBuilderContext } from '../../context';
 import { ISavedFilter } from '../../types';
+
 import EditFilterModal from './EditFilterModal';
 import { deleteFilterConfirm } from './utils';
 
@@ -19,7 +21,7 @@ interface OwnProps {
     onUpdateFilter: ((filter: ISavedFilter) => void) | undefined;
 }
 
-const ManageFiltersModal = ({ visible, savedFilters, onVisibleChange, onDeleteFilter, onUpdateFilter }: OwnProps) => {
+const ManageFiltersModal = ({ onDeleteFilter, onUpdateFilter, onVisibleChange, savedFilters, visible }: OwnProps) => {
     const { dictionary } = useContext(QueryBuilderContext);
     const { locale } = useContext(ConfigProvider.ConfigContext);
     const [isEditModalVisible, setEditModalVisible] = useState(false);
@@ -45,21 +47,21 @@ const ManageFiltersModal = ({ visible, savedFilters, onVisibleChange, onDeleteFi
 
         return (
             <ListItemWithActions
-                title={item.title}
                 description={
                     lastSavedAt &&
                     (dictionary.queryBuilderHeader?.manageFilters?.lastSavedAt
                         ? dictionary.queryBuilderHeader?.manageFilters?.lastSavedAt.replace('{date}', lastSavedAt)
                         : `Last saved : ${lastSavedAt} ago`)
                 }
-                onEdit={() => showEditModal(item)}
                 onDelete={() =>
                     deleteFilterConfirm({
                         dictionary,
-                        savedFilter: item,
                         onDeleteFilter,
+                        savedFilter: item,
                     })
                 }
+                onEdit={() => showEditModal(item)}
+                title={item.title}
             />
         );
     };
@@ -67,27 +69,26 @@ const ManageFiltersModal = ({ visible, savedFilters, onVisibleChange, onDeleteFi
     return (
         <Fragment>
             <Modal
-                visible={visible}
+                cancelButtonProps={{ style: { display: 'none' } }}
+                okText={dictionary.queryBuilderHeader?.manageFilters?.okText || 'Close'}
                 onCancel={onDismiss}
                 onOk={onDismiss}
                 title={dictionary.queryBuilderHeader?.manageFilters?.modalTitle || 'Manage filters'}
-                okText={dictionary.queryBuilderHeader?.manageFilters?.okText || 'Close'}
-                cancelButtonProps={{ style: { display: 'none' } }}
+                visible={visible}
                 width={600}
             >
                 <List
-                    className={styles.QBHManageFiltersList}
                     bordered
+                    className={styles.QBHManageFiltersList}
                     dataSource={savedFilters}
                     renderItem={getListItem}
                 />
             </Modal>
             <EditFilterModal
-                visible={isEditModalVisible}
-                onCancel={() => setEditModalVisible(false)}
                 initialTitleValue={selectedFilter?.title!}
-                okDisabled={false}
                 isNewFilter={false}
+                okDisabled={false}
+                onCancel={() => setEditModalVisible(false)}
                 onSubmit={(title) => {
                     setEditModalVisible(false);
                     if (onUpdateFilter) {
@@ -97,6 +98,7 @@ const ManageFiltersModal = ({ visible, savedFilters, onVisibleChange, onDeleteFi
                         });
                     }
                 }}
+                visible={isEditModalVisible}
             />
         </Fragment>
     );

--- a/packages/ui/src/components/QueryBuilder/Header/index.tsx
+++ b/packages/ui/src/components/QueryBuilder/Header/index.tsx
@@ -1,21 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { EditOutlined, StarFilled, StarOutlined, UndoOutlined } from '@ant-design/icons';
 import { Button, Space, Tooltip, Typography } from 'antd';
 import cx from 'classnames';
-import React, { useEffect, useState } from 'react';
 import { v4 } from 'uuid';
 
 import { getDefaultSyntheticSqon } from '../../../data/sqon/utils';
 import Collapse, { CollapsePanel } from '../../Collapse';
+import { QueryBuilderContext } from '../context';
 import { ISavedFilter, TOnSavedFilterChange } from '../types';
 import { setQueryBuilderState } from '../utils/useQueryBuilderState';
 
+import EditFilterModal from './Tools/EditFilterModal';
 import QueryBuilderHeaderTools from './Tools';
 import { hasUnsavedChanges, isNewUnsavedFilter } from './utils';
 
 import styles from '@ferlab/style/components/queryBuilder/QueryBuilderHeader.module.scss';
-import { useContext } from 'react';
-import { QueryBuilderContext } from '../context';
-import EditFilterModal from './Tools/EditFilterModal';
 
 interface IQueryBuilderHeaderProps {
     children: JSX.Element;
@@ -28,7 +28,7 @@ const { Title } = Typography;
 const tooltipAlign = { align: { offset: [0, 5] } };
 
 const QueryBuilderHeader = ({ children, onSavedFilterChange, resetQueriesState }: IQueryBuilderHeaderProps) => {
-    const { queryBuilderId, dictionary, headerConfig, queriesState, selectedSavedFilter } =
+    const { dictionary, headerConfig, queriesState, queryBuilderId, selectedSavedFilter } =
         useContext(QueryBuilderContext);
     const [savedFilterTitle, setSavedFilterTitle] = useState('');
     const [isEditModalVisible, setEditModalVisible] = useState(false);
@@ -87,6 +87,11 @@ const QueryBuilderHeader = ({ children, onSavedFilterChange, resetQueriesState }
                     onDeleteFilter: onDeleteFilter,
                     onSaveFilter: onSaveFilter,
                     onUpdateFilter: onUpdateFilter,
+                    onUpdateFilterModal: (savedFilter: ISavedFilter) => {
+                        if (headerConfig?.onUpdateFilter) {
+                            headerConfig.onUpdateFilter(savedFilter);
+                        }
+                    },
                 }}
                 onDuplicateSavedFilter={() => {
                     const duplicatedQueries = [...queriesState.queries].map((query) => ({
@@ -131,8 +136,8 @@ const QueryBuilderHeader = ({ children, onSavedFilterChange, resetQueriesState }
                     arrowIcon: headerConfig.collapseProps?.arrowIcon ?? 'caretFilled',
                     size: headerConfig.collapseProps?.size ?? 'large',
                 }}
-                defaultActiveKey={'query-header-tools'}
                 className={styles.QBHCollapse}
+                defaultActiveKey={'query-header-tools'}
             >
                 <CollapsePanel
                     extra={getExtra()}
@@ -236,11 +241,10 @@ const QueryBuilderHeader = ({ children, onSavedFilterChange, resetQueriesState }
                 </CollapsePanel>
             </Collapse>
             <EditFilterModal
-                visible={isEditModalVisible}
-                onCancel={() => setEditModalVisible(false)}
-                okDisabled={!localSavedFilters}
                 initialTitleValue={savedFilterTitle || selectedSavedFilter?.title!}
                 isNewFilter={isNewUnsavedFilter(selectedSavedFilter!, localSavedFilters!)}
+                okDisabled={!localSavedFilters}
+                onCancel={() => setEditModalVisible(false)}
                 onSubmit={(title) => {
                     setEditModalVisible(false);
                     setSavedFilterTitle(title);
@@ -254,6 +258,7 @@ const QueryBuilderHeader = ({ children, onSavedFilterChange, resetQueriesState }
                         onUpdateFilter(filterToSave);
                     }
                 }}
+                visible={isEditModalVisible}
             />
         </div>
     );

--- a/packages/ui/src/components/QueryBuilder/types.ts
+++ b/packages/ui/src/components/QueryBuilder/types.ts
@@ -62,6 +62,7 @@ export interface IQueryBuilderHeaderConfig {
     collapseProps?: Omit<TCollapseProps, 'defaultActiveKey'>;
     onSetAsFavorite?: (filter: ISavedFilter) => void;
     onUpdateFilter?: (filter: ISavedFilter) => void;
+    onUpdateFilterModal?: (filter: ISavedFilter) => void;
     onShareFilter?: (filter: ISavedFilter) => void;
     onSaveFilter?: (filter: ISavedFilter) => void;
     onDeleteFilter?: (filterId: string) => void;


### PR DESCRIPTION
…urrent one

# BUG
- closes #[22](https://ferlab-crsj.atlassian.net/browse/FLUI-22)

## Description

Pour reproduire

Activer un filtre (filtre X) dans la page

Dans le modal de gestion renommer un autre filtre (filtre Y)


1. Le filtre Y est bien renommé, mais ses requêtes ont été écrasées par celles du filtre X (Voir le premier vidéo).

2. Le modal d'édition du filtre Y affiche le nom du filtre X (Voir le deuxième vidéo).



Acceptance Criterias

## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
![Peek 2022-12-07 11-34](https://user-images.githubusercontent.com/65532894/206237654-d8a9102c-ea20-4eff-8c60-04d746a2bae6.gif)



### After
![Peek 2022-12-07 11-30](https://user-images.githubusercontent.com/65532894/206235874-351923a5-f881-4f48-b789-f8d019f8c053.gif)
![Peek 2022-12-07 11-302](https://user-images.githubusercontent.com/65532894/206235877-91373d8a-d898-4c2e-8153-f97150f9b63c.gif)


## Mention
@luclemo @kstonge

