### PR TITLE
Feat/fl UI 25 26/fix table and query builder tools

### DIFF
--- a/packages/style/components/queryBuilder/QueryBuilderHeaderTools.module.scss
+++ b/packages/style/components/queryBuilder/QueryBuilderHeaderTools.module.scss
@@ -3,11 +3,6 @@
 .queryBuilderHeaderTools {
   .toolsContainer {
     .queryBuilderHeaderActionIconBtn {
-      &:focus,
-      &:hover {
-        background-color: transparent;
-      }
-
       &:focus-visible {
         border: 1px solid !important;
       }
@@ -19,18 +14,20 @@
           color: $query-builder-header-tools-icon-color-dirty;
 
           &:not(span) {
-            @include hoverFocus(
-              $query-builder-header-tools-icon-color-dirty,
-              $query-builder-header-tools-icon-color-dirty
-            );
+            &:hover,
+            &:focus {
+              border: $query-builder-header-tools-icon-color-dirty;
+              color: $query-builder-header-tools-icon-color-dirty;
+            }
           }
         }
 
         &:not(span) {
-          @include hoverFocus(
-            $query-builder-header-tools-icon-hover,
-            $query-builder-header-tools-icon-focus
-          );
+          &:hover,
+          &:focus {
+            border: $query-builder-header-tools-icon-color-dirty;
+            color: $query-builder-header-tools-icon-color-dirty;
+          }
         }
       }
     }

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/style",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.7.7",
+    "version": "4.7.8",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"
@@ -79,7 +79,6 @@
         "md5": "^2.3.0",
         "query-string": "^7.0.1",
         "react-icons": "^4.2.0",
-        "simplebar-react": "^2.3.6",
         "uuid": "^8.3.2",
         "xss": "^1.0.9"
     },

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -4,6 +4,8 @@ import { Button, Space, Table, Tooltip } from 'antd';
 import cx from 'classnames';
 import { isEmpty } from 'lodash';
 
+import Empty from '../Empty';
+
 import ColumnSelector from './ColumnSelector';
 import TableHeader from './Header';
 import Pagination from './Pagination';
@@ -215,6 +217,9 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                     .map(({ key }) => columns.find((column) => column.key === key)!)
                     .filter((column) => !isEmpty(column))
                     .map(generateColumnTitle)}
+                locale={{
+                    emptyText: <Empty description={dictionary.table?.emptyText || 'No available data'} size="mini" />,
+                }}
                 pagination={
                     pagination && (pagination as IPaginationProps)?.searchAfter === undefined
                         ? {

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -50,6 +50,9 @@ export interface IProTableDictionary {
         view: string;
     };
     numberFormat?: (value: number) => React.ReactNode;
+    table?: {
+        emptyText: string;
+    };
 }
 
 export interface ProColumnType<T = any> extends ColumnType<T> {


### PR DESCRIPTION
# FEATURE

- closes #[25](https://ferlab-crsj.atlassian.net/browse/FLUI-25)
- closes #[26](https://ferlab-crsj.atlassian.net/browse/FLUI-26)

## Description

QueryBuilderHEaderTools surcharge le hover des boutons et retire le background. Cependant, il devrait garder le fonctionnement des bases des boutons.
Ajouter une clé de traduction pour pouvoir redéfinier la props description de Empty lorsqu’aucun résultat n’est sortie

A noter qu'à cause de problème de builds, la capture d'écran de querytools a été prise via storybook

Acceptance Criterias

## Validation de Qualité

- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
![Screenshot_20221214_143845](https://user-images.githubusercontent.com/65532894/207701419-0fc42483-c8e8-45be-8ee6-99046aecf19a.png)


##
![Screenshot_20221214_143819](https://user-images.githubusercontent.com/65532894/207701440-454867ba-4b00-4399-b0de-1470b907f623.png)
# After
![Screenshot_20221214_145119](https://user-images.githubusercontent.com/65532894/207701454-3d9ff2d6-5f29-4b3d-9a71-8ad787a375c0.png)


## Mention
@luclemo @kstonge

