### PR TITLE
Feat/skfp 575/view save

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.7.9",
+    "version": "4.8.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -19,6 +19,7 @@ const Pagination = ({
     onChange,
     onPageChange,
     onShowSizeChange,
+    onViewQueryChange,
     queryConfig,
     searchAfter,
     setQueryConfig,
@@ -39,6 +40,10 @@ const Pagination = ({
                         size: viewPerQuery,
                         sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
                     });
+
+                    if (onViewQueryChange) {
+                        onViewQueryChange(viewPerQuery);
+                    }
                     onShowSizeChange();
                 }}
                 options={getPaginationOptions(dictionary?.pagination?.view || '{value} / view')}
@@ -97,7 +102,6 @@ const Pagination = ({
                         searchAfter: searchAfter?.tail,
                         sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
                     });
-
                     onPageChange();
                     onChange(current + 1, queryConfig.size);
                 }}

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -41,9 +41,7 @@ const Pagination = ({
                         sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
                     });
 
-                    if (onViewQueryChange) {
-                        onViewQueryChange(viewPerQuery);
-                    }
+                    onViewQueryChange?.(viewPerQuery);
                     onShowSizeChange();
                 }}
                 options={getPaginationOptions(dictionary?.pagination?.view || '{value} / view')}

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -16,6 +16,7 @@ export interface IPaginationProps {
     setQueryConfig: TQueryConfigCb;
     queryConfig: IQueryConfig;
     defaultViewPerQuery?: PaginationViewPerQuery;
+    onViewQueryChange?: (viewPerQuery: PaginationViewPerQuery) => void;
     searchAfter?: ISearchAfter;
     onPageChange: () => void;
     onShowSizeChange: () => void;

--- a/packages/ui/src/pages/VariantEntity/Consequences/index.tsx
+++ b/packages/ui/src/pages/VariantEntity/Consequences/index.tsx
@@ -207,7 +207,7 @@ export const getColumns = (dictionary: IVariantEntityDictionary['consequences'])
                     dataSource={consequences}
                     renderItem={(item: any, id) => (
                         <StackLayout className={styles.cellList} horizontal key={id}>
-                            <Text>{item}</Text>
+                            <Text>{item.replaceAll('_', ' ')}</Text>
                         </StackLayout>
                     )}
                 />


### PR DESCRIPTION
# FEATURE

- closes #[575](https://d3b.atlassian.net/browse/SKFP-575)
- closes #[581](https://d3b.atlassian.net/browse/SKFP-581)

## Description

1. Vincent requested we adjust the default row view from 10/view to 20/view. Also save the user’s parameter to the latest row view setting. E.g. if the user select 100/view, closes his session, relogs in, the table of results should be maintained at 100/view and not reinitialized to 20/view (being the default).
2. Replace underscores with spaces for Interpretation and Consequences values in Variant Entity page.

Acceptance Criterias

## Validation de Qualité

- [ ] Validation du design avec design figma (dev)
- [ ] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot

https://user-images.githubusercontent.com/65532894/208143193-76beeb09-fc07-44ed-8775-f65b1794037d.mp4
![Screenshot_20221216_112019](https://user-images.githubusercontent.com/65532894/208143227-2a4af366-79f8-4ec5-9de6-64e76e24801f.png)



## Mention
@luclemo @kstonge

