### PR TITLE
✨feat(querybar): SKFP-596 add an remoteComponent properties, it will …

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.9.1",
+    "version": "4.10.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/QueryPills/BooleanQueryPill.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryPills/BooleanQueryPill.tsx
@@ -1,14 +1,22 @@
 import React, { Fragment } from 'react';
 import { Space } from 'antd';
 
-import { ISqonGroupFilter, ISyntheticSqon, IValueContent, IValueFilter, TSqonGroupOp } from '../../../data/sqon/types';
-import { isBooleanOperator, isReference, isSet, isUploadedList } from '../../../data/sqon/utils';
+import {
+    IRemoteComponent,
+    ISqonGroupFilter,
+    ISyntheticSqon,
+    IValueContent,
+    IValueFilter,
+    TSqonGroupOp,
+} from '../../../data/sqon/types';
+import { isBooleanOperator, isReference, isRemoteComponent, isSet, isUploadedList } from '../../../data/sqon/utils';
 import Combiner from '../Combiner';
 import { TCallbackRemoveAction, TCallbackRemoveReferenceAction } from '../types';
 
 import FieldQueryPill from './FieldQueryPill';
 import IsolatedBooleanQueryPill from './IsolatedBooleanQueryPill';
 import ReferenceQueryPill from './ReferenceQueryPill';
+import RemoveComponentQueryPill from './RemoteComponentQueryPill';
 import SetQueryPill from './SetQueryPill';
 import UploadedListQueryPill from './UploadedListQueryPill';
 
@@ -20,6 +28,7 @@ interface IBooleanQueryPillProps {
     onRemoveReference: TCallbackRemoveReferenceAction;
     onCombineChange?: (id: string, combinator: TSqonGroupOp) => void;
     getColorForReference?: (refIndex: number) => string;
+    remoteComponentMapping?: (props: IRemoteComponent) => void;
 }
 
 const isNotEnd = (content: any[], index: number) => content.length - 1 > index;
@@ -58,6 +67,13 @@ const BooleanQueryPill = (props: IBooleanQueryPillProps) => (
                     <UploadedListQueryPill
                         isBarActive={props.isActive}
                         onRemove={() => props.onRemoveFacet((f as IValueFilter).content.field, props.query)}
+                        valueFilter={f as IValueFilter}
+                    />
+                ) : isRemoteComponent(f) ? (
+                    <RemoveComponentQueryPill
+                        isBarActive={props.isActive}
+                        onRemove={() => props.onRemoveFacet((f as IValueFilter).content.field, props.query)}
+                        remoteComponentMapping={props.remoteComponentMapping}
                         valueFilter={f as IValueFilter}
                     />
                 ) : (

--- a/packages/ui/src/components/QueryBuilder/QueryPills/FieldQueryPill.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryPills/FieldQueryPill.tsx
@@ -1,11 +1,13 @@
-import { Button, Dropdown, Spin } from 'antd';
-import cx from 'classnames';
 import React, { Fragment, useContext, useEffect, useState } from 'react';
 import { AiOutlineClose } from 'react-icons/ai';
+import { Button, Dropdown, Spin } from 'antd';
+import cx from 'classnames';
+
 import { FieldOperators } from '../../../data/sqon/operators';
 import { IValueFilter } from '../../../data/sqon/types';
 import { isBooleanFilter, isRangeFilter } from '../../../data/sqon/utils';
 import ConditionalWrapper from '../../utils/ConditionalWrapper';
+import { QueryBuilderContext } from '../context';
 import ElementOperator from '../icons/ElementOperator';
 import EqualOperator from '../icons/EqualOperator';
 import GreaterThanOperator from '../icons/GreaterThanOperator';
@@ -16,7 +18,6 @@ import NotInOperator from '../icons/NotInOperator';
 import QueryValues from '../QueryValues';
 
 import styles from '@ferlab/style/components/queryBuilder/QueryPill.module.scss';
-import { QueryBuilderContext } from '../context';
 
 interface IFieldQueryPillProps {
     isBarActive?: boolean;
@@ -31,7 +32,7 @@ interface IOperatorProps {
 
 const APPLY_KEY = 'apply';
 
-const Operator = ({ className = '', type }: IOperatorProps) => {
+export const Operator = ({ className = '', type }: IOperatorProps) => {
     switch (type) {
         case FieldOperators['>']:
             return <GreaterThanOperator className={className} />;
@@ -51,7 +52,7 @@ const Operator = ({ className = '', type }: IOperatorProps) => {
     }
 };
 
-const FieldQueryPill = ({ valueFilter, onRemove, isBarActive }: IFieldQueryPillProps) => {
+const FieldQueryPill = ({ isBarActive, onRemove, valueFilter }: IFieldQueryPillProps) => {
     const { dictionary, facetFilterConfig, showLabels } = useContext(QueryBuilderContext);
     const [tryOpenQueryPillFilter, setTryOpenQueryPillFilter] = useState(false);
     const [filterDropdownVisible, setFilterDropdownVisible] = useState(false);
@@ -64,9 +65,8 @@ const FieldQueryPill = ({ valueFilter, onRemove, isBarActive }: IFieldQueryPillP
             setTryOpenQueryPillFilter(true);
         }
     };
-    const isFacetFilterEnableForField = () => {
-        return facetFilterConfig.enable && !facetFilterConfig.blacklistedFacets?.includes(valueFilter.content.field);
-    };
+    const isFacetFilterEnableForField = () =>
+        facetFilterConfig.enable && !facetFilterConfig.blacklistedFacets?.includes(valueFilter.content.field);
 
     useEffect(() => {
         if (facetFilterConfig.selectedFilterContent) {
@@ -96,14 +96,13 @@ const FieldQueryPill = ({ valueFilter, onRemove, isBarActive }: IFieldQueryPillP
                 condition={isFacetFilterEnableForField()}
                 wrapper={(children) => (
                     <Dropdown
-                        visible={filterDropdownVisible}
+                        getPopupContainer={(trigger) => trigger.parentElement!}
                         onVisibleChange={(visible) => {
                             if (visible) {
                                 setDropdownContent(undefined);
                             }
                             setFilterDropdownVisible(visible);
                         }}
-                        overlayClassName={styles.filtersDropdown}
                         overlay={
                             <div
                                 onClick={(e: any) => {
@@ -119,16 +118,17 @@ const FieldQueryPill = ({ valueFilter, onRemove, isBarActive }: IFieldQueryPillP
                                 )}
                             </div>
                         }
+                        overlayClassName={styles.filtersDropdown}
                         trigger={['click']}
-                        getPopupContainer={(trigger) => trigger.parentElement!}
+                        visible={filterDropdownVisible}
                     >
                         {children}
                     </Dropdown>
                 )}
             >
                 <QueryValues
-                    onClick={isFacetFilterEnableForField() ? () => handleQueryPillClick(isBarActive!) : undefined}
                     isElement={valueFilter.op === FieldOperators.between}
+                    onClick={isFacetFilterEnableForField() ? () => handleQueryPillClick(isBarActive!) : undefined}
                     valueFilter={valueFilter}
                 />
             </ConditionalWrapper>

--- a/packages/ui/src/components/QueryBuilder/QueryPills/RemoteComponentQueryPill.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryPills/RemoteComponentQueryPill.tsx
@@ -1,0 +1,73 @@
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import { AiOutlineClose } from 'react-icons/ai';
+import { Button } from 'antd';
+import cx from 'classnames';
+
+import { IRemoteComponent, IValueFilter } from '../../../data/sqon/types';
+import { isBooleanFilter, isRangeFilter } from '../../../data/sqon/utils';
+import { QueryBuilderContext } from '../context';
+import QueryValues from '../QueryValues';
+
+import { Operator } from './FieldQueryPill';
+
+import styles from '@ferlab/style/components/queryBuilder/QueryPill.module.scss';
+
+interface IFieldQueryPillProps {
+    isBarActive?: boolean;
+    valueFilter: IValueFilter;
+    onRemove: () => void;
+    remoteComponentMapping?: (props: IRemoteComponent) => void;
+}
+
+const RemoveComponentQueryPill = ({
+    isBarActive,
+    onRemove,
+    remoteComponentMapping,
+    valueFilter,
+}: IFieldQueryPillProps): ReactElement => {
+    const { dictionary, showLabels } = useContext(QueryBuilderContext);
+    const [tryOpenQueryPillFilter, setTryOpenQueryPillFilter] = useState(false);
+    const handleQueryPillClick = (isBarActive: boolean) => {
+        if (remoteComponentMapping && valueFilter.content.remoteComponent) {
+            remoteComponentMapping(valueFilter.content.remoteComponent);
+        }
+
+        setTryOpenQueryPillFilter(!isBarActive);
+    };
+
+    useEffect(() => {
+        if (tryOpenQueryPillFilter) {
+            handleQueryPillClick(isBarActive!);
+        }
+    }, [isBarActive]);
+
+    return (
+        <div className={cx(styles.queryPillContainer, { [styles.selected]: isBarActive })}>
+            {(showLabels || isBooleanFilter(valueFilter) || isRangeFilter(valueFilter)) && (
+                <>
+                    <span className={`${styles.field}`}>
+                        {dictionary.query?.facet
+                            ? dictionary.query?.facet(valueFilter.content.field)
+                            : valueFilter.content.field}
+                    </span>
+                    <Operator className={styles.operator} type={valueFilter.op} />
+                </>
+            )}
+            <QueryValues
+                isElement={true}
+                onClick={() => handleQueryPillClick(!!isBarActive)}
+                valueFilter={valueFilter}
+            />
+            <Button className={styles.close} type="text">
+                <AiOutlineClose
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onRemove();
+                    }}
+                />
+            </Button>
+        </div>
+    );
+};
+
+export default RemoveComponentQueryPill;

--- a/packages/ui/src/components/QueryBuilder/index.tsx
+++ b/packages/ui/src/components/QueryBuilder/index.tsx
@@ -4,7 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import { v4 } from 'uuid';
 
 import { BooleanOperators } from '../../data/sqon/operators';
-import { ISyntheticSqon, TSyntheticSqonContent } from '../../data/sqon/types';
+import { IRemoteComponent, ISyntheticSqon, TSyntheticSqonContent } from '../../data/sqon/types';
 import {
     changeCombineOperator,
     getDefaultSyntheticSqon,
@@ -50,6 +50,7 @@ export interface IQueryBuilderProps {
     facetFilterConfig?: IFacetFilterConfig;
     fetchQueryCount: IFetchQueryCount;
     getResolvedQueryForCount: IGetResolvedQueryForCount;
+    remoteComponentMapping?: (props: IRemoteComponent) => void;
 }
 
 const QueryBuilder = ({
@@ -84,6 +85,7 @@ const QueryBuilder = ({
     facetFilterConfig = defaultFacetFilterConfig,
     fetchQueryCount,
     getResolvedQueryForCount,
+    remoteComponentMapping,
 }: IQueryBuilderProps) => {
     const [selectedSavedFilter, setSelectedSavedFilter] = useState(headerConfig?.selectedSavedFilter || null);
     const { state: queryBuilderState } = useQueryBuilderState(id);
@@ -397,6 +399,7 @@ const QueryBuilder = ({
                                     setSelectedQueryIndices([...selectedQueryIndices, id]);
                                 }}
                                 query={sqon}
+                                remoteComponentMapping={remoteComponentMapping}
                                 selectionDisabled={
                                     queriesState.queries.length === 1 ||
                                     !enableCombine ||

--- a/packages/ui/src/components/QueryBuilder/utils/useQueryBuilderState.tsx
+++ b/packages/ui/src/components/QueryBuilder/utils/useQueryBuilderState.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 import { v4 } from 'uuid';
 
 import { BooleanOperators, RangeOperators, TermOperators } from '../../../data/sqon/operators';
-import { TSqonGroupOp } from '../../../data/sqon/types';
+import { IRemoteComponent, TSqonGroupOp } from '../../../data/sqon/types';
 import { ISyntheticSqon, MERGE_VALUES_STRATEGIES } from '../../../data/sqon/types';
 import {
     deepMergeFieldInActiveQuery,
@@ -133,6 +133,7 @@ export const updateActiveQueryField = ({
     index,
     overrideValuesName,
     isUploadedList,
+    remoteComponent,
 }: {
     queryBuilderId: string;
     field: string;
@@ -142,7 +143,8 @@ export const updateActiveQueryField = ({
     index?: string;
     overrideValuesName?: string;
     isUploadedList?: boolean;
-}) =>
+    remoteComponent?: IRemoteComponent;
+}): void =>
     updateQuery({
         query: isEmpty(value)
             ? removeFieldFromActiveQuery(queryBuilderId, field)
@@ -154,6 +156,7 @@ export const updateActiveQueryField = ({
                   operator,
                   overrideValuesName,
                   queryBuilderId,
+                  remoteComponent,
                   value,
               }),
         queryBuilderId,

--- a/packages/ui/src/data/sqon/types.ts
+++ b/packages/ui/src/data/sqon/types.ts
@@ -1,12 +1,19 @@
 import { BooleanOperators, FieldOperators } from './operators';
 
 export type TFilterValue = Array<string | number | boolean>;
+export interface IRemoteComponent {
+    id: string;
+    props?: {
+        [value: string]: any;
+    };
+}
 export interface IValueContent {
     field: string;
     value: TFilterValue;
     index?: string;
     overrideValuesName?: string;
     isUploadedList?: boolean;
+    remoteComponent?: IRemoteComponent;
 }
 
 export type TValueOp = FieldOperators | string;

--- a/packages/ui/src/data/sqon/utils.ts
+++ b/packages/ui/src/data/sqon/utils.ts
@@ -16,6 +16,7 @@ import { getSelectedFiltersForRange } from '../filters/Range';
 import { BooleanOperators, FieldOperators, RangeOperators, TermOperators } from './operators';
 import {
     IMergeOptions,
+    IRemoteComponent,
     ISqonGroupFilter,
     ISyntheticSqon,
     IValueContent,
@@ -68,6 +69,13 @@ export const isNotSet = (value: IValueFilter) => !isSet(value);
  * @param {IValueFilter} value The value to check
  */
 export const isUploadedList = (value: IValueFilter): boolean => Boolean(value.content.isUploadedList);
+
+/**
+ *
+ * @param value Check if a sqon value is a treefacet
+ * @returns
+ */
+export const isRemoteComponent = (value: IValueFilter): boolean => !!value.content.remoteComponent;
 
 /**
  * Check if a synthetic sqon is a boolean operator
@@ -389,6 +397,7 @@ export const deepMergeFieldInActiveQuery = ({
     operator = TermOperators.in,
     overrideValuesName,
     isUploadedList,
+    remoteComponent,
 }: {
     queryBuilderId: string;
     field: string;
@@ -398,6 +407,7 @@ export const deepMergeFieldInActiveQuery = ({
     operator?: TermOperators | RangeOperators;
     overrideValuesName?: string;
     isUploadedList?: boolean;
+    remoteComponent?: IRemoteComponent;
 }) => {
     let newSqon;
     const activeQuery = getActiveQuery(queryBuilderId);
@@ -407,6 +417,7 @@ export const deepMergeFieldInActiveQuery = ({
             index,
             isUploadedList,
             overrideValuesName,
+            remoteComponent,
             value,
         },
         op: operator,

--- a/storybook/stories/Components/QueryBuilder/QueryBuilder.stories.tsx
+++ b/storybook/stories/Components/QueryBuilder/QueryBuilder.stories.tsx
@@ -1,7 +1,8 @@
 import QueryBuilder, {
-    IQueryBuilderProps
+    IQueryBuilderProps,
 } from "@ferlab/ui/components/QueryBuilder";
 import { setQueryBuilderState } from "@ferlab/ui/components/QueryBuilder/utils/useQueryBuilderState";
+import { IRemoteComponent } from "@ferlab/ui/data/sqon/types";
 import { Meta, Story } from "@storybook/react/types-6-0";
 import React from "react";
 import { MdPeople } from "react-icons/md";
@@ -523,7 +524,7 @@ WithHeaderAndTools.args = {
                 ],
                 total: 1500,
                 id: "1",
-                updated_date: "2022-09-23T03:02:01.286Z"
+                updated_date: "2022-09-23T03:02:01.286Z",
             },
             {
                 title: "My query 2",
@@ -544,8 +545,8 @@ WithHeaderAndTools.args = {
                 ],
                 total: 1500,
                 id: "2",
-                updated_date: "2022-09-23T03:02:01.286Z"
-            }
+                updated_date: "2022-09-23T03:02:01.286Z",
+            },
         ],
         onSaveQuery: (filter: any) => {
             console.log(filter);
@@ -631,4 +632,44 @@ WithNameMapping.args = {
         },
     },
     IconTotal: <MdPeople />,
+};
+
+/* remoteComponent */
+export const RemoteComponentQuery = QueryBuilderStory.bind({});
+const RemoteComponentQueryQbId = QB_ID + "RemoteComponentQuery";
+setQueryBuilderState(RemoteComponentQueryQbId, {
+    state: [
+        {
+            op: "and",
+            content: [
+                {
+                    content: {
+                        value: ["something"],
+                        field: "test",
+                        remoteComponent: {
+                            id: "remoteComponent",
+                            props: {
+                                customProps: "customProps",
+                            },
+                        },
+                    },
+                    op: "in",
+                },
+            ],
+            total: 1500,
+            id: "1",
+        },
+    ],
+    active: "1",
+});
+RemoteComponentQuery.args = {
+    id: RemoteComponentQueryQbId,
+    title: "Remote Component",
+    onRemoveFacet: (f: any) => f,
+    onChangeQuery: (f: any) => f,
+    getResolvedQueryForCount: defaultResolveCountPromise,
+    fetchQueryCount: defaultFetchQuerCount,
+    remoteComponentMapping: (remoteComponent: IRemoteComponent) => {
+        console.log("remoteComponentMapping has been called", remoteComponent);
+    },
 };


### PR DESCRIPTION
…trigger a component on the client side

# FEATURE

- closes #[596](https://d3b.atlassian.net/browse/SKFP-596)

## Description
![Peek 2023-01-13 14-00](https://user-images.githubusercontent.com/65532894/212398202-bd0c099d-ced8-4bfe-815a-50c057205bda.gif)

Some components use way too many custom functions to be ported in ferlab-ui. Like Observed Phenotype (HPO) Browser, a custom model that create his own custom store when displayed. 

To contour this behavior, I added a remoteComponent behavior. When added, it will trigger a store action on the client side and open the modal (and any other custom component). The change on the client side can be see [right here](https://github.com/kids-first/kf-portal-ui/pull/3655) 

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/65532894/212399037-ea0793eb-fb3a-4456-8b40-040a7bf16f75.png)


### After
![Peek 2023-01-13 14-00](https://user-images.githubusercontent.com/65532894/212398202-bd0c099d-ced8-4bfe-815a-50c057205bda.gif)

## Mention
@luclemo @kstonge

