### PR TITLE
fix: SJIP:350 Default icon size for entity pages

### DIFF
--- a/packages/style/Release.md
+++ b/packages/style/Release.md
@@ -1,3 +1,6 @@
+### 1.28.1 | 2023-02-02
+- Fix: SJIP-350 Set default icon size for entity pages
+
 ### 1.28.0 | 2023-01-23
 - Feat: CQDG-31 add EntityTableMultiple component on EntityPage
 

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ferlab/style",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Core components for scientific research data portals",
   "publishConfig": {
     "access": "public"

--- a/packages/style/pages/EntityPage/EntityTable.module.scss
+++ b/packages/style/pages/EntityPage/EntityTable.module.scss
@@ -45,15 +45,3 @@
     align-items: center;
   }
 }
-
-.dotted {
-  border-bottom: 1px dotted;
-}
-
-.link {
-  text-decoration: underline;
-
-  &:hover {
-    text-decoration: none;
-  }
-}

--- a/packages/style/pages/EntityPage/EntityTitle.module.scss
+++ b/packages/style/pages/EntityPage/EntityTitle.module.scss
@@ -18,4 +18,8 @@
     .extra {
       margin-left: auto;
     }
+
+    .icon {
+      font-size: $entity-icon-size;
+    }
   }

--- a/packages/style/themes/default/_theme.template.scss
+++ b/packages/style/themes/default/_theme.template.scss
@@ -156,3 +156,6 @@ $variant-tag-color: #531DAB;
 $variant-tag-bg-color: #EFDBFF;
 $canonical-icon-color: $blue-8;
 $summary-bg-color: $gray-3;
+
+// Entities
+$entity-icon-size: 20px;

--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 4.13.1 | 2023-02-02
+- Fix: SJIP-350 Set default icon size for entity pages
+
 ### 4.12.0 | 2023-01-23
 - Feat: CQDG-31 add EntityTableMultiple component on EntityPage
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.7.3",
+    "version": "4.11.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "4.7.3",
+            "version": "4.11.2",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -18,7 +18,7 @@
                 "md5": "^2.3.0",
                 "query-string": "^7.0.1",
                 "react-icons": "^4.2.0",
-                "simplebar-react": "^2.3.6",
+                "simplebar-react": "^2.4.3",
                 "uuid": "^8.3.2",
                 "xss": "^1.0.9"
             },
@@ -1337,9 +1337,9 @@
             }
         },
         "node_modules/@juggle/resize-observer": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-            "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -10855,9 +10855,9 @@
             "dev": true
         },
         "node_modules/simplebar": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.8.tgz",
-            "integrity": "sha512-LOHjyOcihx++zFN+vuktoZBGpCarFCtHIVDWXOf2VELbGDknq3Hw/sddafRp1aCg123VNkHWOFHUDHYEXAtufQ==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.9.tgz",
+            "integrity": "sha512-1vIIpjDvY9sVH14e0LGeiCiTFU3ILqAghzO6OI9axeG+mvU/vMSrvXeAXkBolqFFz3XYaY8n5ahH9MeP3sp2Ag==",
             "dependencies": {
                 "@juggle/resize-observer": "^3.3.1",
                 "can-use-dom": "^0.1.0",
@@ -10868,12 +10868,12 @@
             }
         },
         "node_modules/simplebar-react": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.1.tgz",
-            "integrity": "sha512-lw0ZPj+80ez2mh1YTOligFUNzDch2sUbOzDp4WUhU5SpS+qMiyyOzNfMbHa0l4FyWox+tnGNO7jybxqIda3roQ==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.3.tgz",
+            "integrity": "sha512-Ep8gqAUZAS5IC2lT5RE4t1ZFUIVACqbrSRQvFV9a6NbVUzXzOMnc4P82Hl8Ak77AnPQvmgUwZS7aUKLyBoMAcg==",
             "dependencies": {
                 "prop-types": "^15.6.1",
-                "simplebar": "^5.3.8"
+                "simplebar": "^5.3.9"
             },
             "peerDependencies": {
                 "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0.0",
@@ -14508,9 +14508,9 @@
             }
         },
         "@juggle/resize-observer": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-            "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -21997,9 +21997,9 @@
             "dev": true
         },
         "simplebar": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.8.tgz",
-            "integrity": "sha512-LOHjyOcihx++zFN+vuktoZBGpCarFCtHIVDWXOf2VELbGDknq3Hw/sddafRp1aCg123VNkHWOFHUDHYEXAtufQ==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.9.tgz",
+            "integrity": "sha512-1vIIpjDvY9sVH14e0LGeiCiTFU3ILqAghzO6OI9axeG+mvU/vMSrvXeAXkBolqFFz3XYaY8n5ahH9MeP3sp2Ag==",
             "requires": {
                 "@juggle/resize-observer": "^3.3.1",
                 "can-use-dom": "^0.1.0",
@@ -22010,12 +22010,12 @@
             }
         },
         "simplebar-react": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.1.tgz",
-            "integrity": "sha512-lw0ZPj+80ez2mh1YTOligFUNzDch2sUbOzDp4WUhU5SpS+qMiyyOzNfMbHa0l4FyWox+tnGNO7jybxqIda3roQ==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.3.tgz",
+            "integrity": "sha512-Ep8gqAUZAS5IC2lT5RE4t1ZFUIVACqbrSRQvFV9a6NbVUzXzOMnc4P82Hl8Ak77AnPQvmgUwZS7aUKLyBoMAcg==",
             "requires": {
                 "prop-types": "^15.6.1",
-                "simplebar": "^5.3.8"
+                "simplebar": "^5.3.9"
             }
         },
         "sisteransi": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.13.0",
+    "version": "4.13.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityTitle/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTitle/index.tsx
@@ -17,7 +17,7 @@ const EntityTitle: React.FC<IEntityTitle> = ({ extra, icon, loading, tag, text }
         <Skeleton loading={loading} paragraph={{ rows: 0 }} />
     ) : (
         <div className={styles.titleHeader}>
-            {icon}
+            {icon && <span className={styles.icon}>{icon}</span>}
             {text && (
                 <Title className={styles.title} level={4}>
                     {text}


### PR DESCRIPTION
# BUG

- closes [SJIP-350](https://d3b.atlassian.net/browse/SJIP-350)

## Description

- Ajustement de la taille par défaut de l'icône des pages entités
- Update du package simplebar-react pour fixer les anchorLink dans Include
- Cleanup de code inutilisé dans EntityTable.module.scss

## Screenshot
### After
![0986927A-B099-41B1-A9DE-46C414617C4E](https://user-images.githubusercontent.com/116835792/216176813-4afb7355-e928-4eb2-8c65-6dd897ba3020.jpeg)
