### PR TITLE
fix: SJIP:364 Add scroll to EntityTable

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 4.15.6 | 2023-02-16
+- Fix: SJIP-364 Add scroll to EntityTable
+
 ### 4.15.1 | 2023-02-16
 - Fix: FLUI-33 Fixed columns in protable cannot be reorder
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.15.5",
+    "version": "4.15.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -100,6 +100,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
     dictionary = {},
     summaryColumns,
     onSelectionChange,
+    tableRef,
     ...tableProps
 }: TProTableProps<RecordType>): React.ReactElement => {
     const [leftColumnsState, setLeftColumnsState] = useState<TColumnStates>(
@@ -269,6 +270,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                 total={headerConfig.itemCount?.total || 0}
             />
             <Table
+                ref={tableRef}
                 {...tableProps}
                 {...tablePropsExtra}
                 columns={leftColumnsState
@@ -357,5 +359,4 @@ const ProTable = <RecordType extends object & { key: string } = any>({
         </Space>
     );
 };
-
 export default ProTable;

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -95,6 +95,7 @@ export type TProTableProps<RecordType> = Omit<TableProps<RecordType>, 'columns' 
     enableRowSelection?: boolean;
     onSelectionChange?: (selectedRows: RecordType[], selectedKeys: any[]) => void;
     summaryColumns?: TProTableSummary[];
+    tableRef?: React.Ref<HTMLDivElement>;
 };
 
 export type THeaderConfig<RecordType> = {

--- a/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Card, Space, Typography } from 'antd';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 
@@ -46,49 +46,70 @@ const EntityTable = ({
     summaryColumns = [],
     title,
     emptyMessage = 'No data available',
-}: IEntityTable): React.ReactElement => (
-    <div className={styles.container} id={id}>
-        {title && (
-            <Title className={styles.title} level={4}>
-                {title}
-            </Title>
-        )}
-        <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} header={header} key="1">
-                <Card className={styles.card} loading={loading}>
-                    {!loading && data.length ? (
-                        <ProTable
-                            bordered={bordered}
-                            columns={columns}
-                            dataSource={data}
-                            dictionary={dictionary}
-                            headerConfig={{
-                                hideItemsCount: true,
-                                itemCount: {
-                                    pageIndex: 0,
-                                    pageSize: 0,
-                                    total: 0,
-                                },
-                                ...headerConfig,
-                            }}
-                            initialColumnState={initialColumnState}
-                            loading={loading}
-                            rowClassName={styles.notStriped}
-                            size={size}
-                            summaryColumns={summaryColumns}
-                            tableHeaderClassName={styles.tableHeader}
-                            tableId={id}
-                            wrapperClassName={styles.contentTable}
-                        />
-                    ) : (
-                        <Space className={styles.content} direction="vertical" size={12}>
-                            <Empty align="left" description={emptyMessage} noPadding showImage={false} size="mini" />
-                        </Space>
-                    )}
-                </Card>
-            </CollapsePanel>
-        </Collapse>
-    </div>
-);
+}: IEntityTable): React.ReactElement => {
+    const tableRef = useRef<HTMLDivElement>(null);
+    const [scroll, setScroll] = useState<{ y: number } | undefined>(undefined);
+
+    useEffect(() => {
+        const height = tableRef.current?.clientHeight ?? 0;
+
+        if (height > 400) {
+            setScroll({ y: 400 });
+        }
+    }, [tableRef, loading, data]);
+
+    return (
+        <div className={styles.container} id={id}>
+            {title && (
+                <Title className={styles.title} level={4}>
+                    {title}
+                </Title>
+            )}
+            <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
+                <CollapsePanel className={styles.panel} header={header} key="1">
+                    <Card className={styles.card} loading={loading}>
+                        {!loading && data.length ? (
+                            <ProTable
+                                bordered={bordered}
+                                columns={columns}
+                                dataSource={data}
+                                dictionary={dictionary}
+                                headerConfig={{
+                                    hideItemsCount: true,
+                                    itemCount: {
+                                        pageIndex: 0,
+                                        pageSize: 0,
+                                        total: 0,
+                                    },
+                                    ...headerConfig,
+                                }}
+                                initialColumnState={initialColumnState}
+                                loading={loading}
+                                rowClassName={styles.notStriped}
+                                scroll={scroll}
+                                size={size}
+                                summaryColumns={summaryColumns}
+                                tableHeaderClassName={styles.tableHeader}
+                                tableId={id}
+                                tableRef={tableRef}
+                                wrapperClassName={styles.contentTable}
+                            />
+                        ) : (
+                            <Space className={styles.content} direction="vertical" size={12}>
+                                <Empty
+                                    align="left"
+                                    description={emptyMessage}
+                                    noPadding
+                                    showImage={false}
+                                    size="mini"
+                                />
+                            </Space>
+                        )}
+                    </Card>
+                </CollapsePanel>
+            </Collapse>
+        </div>
+    );
+};
 
 export default EntityTable;


### PR DESCRIPTION
# BUG

- closes [SJIP-364](https://d3b.atlassian.net/browse/SJIP-364)

## Description

- Add a scroll when EntityTable has a height of at least 400px

## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
### Before
![A633775F-63A4-4BA0-98D6-85CA0C39E71A](https://user-images.githubusercontent.com/116835792/219503192-e92e2c28-e206-45aa-a345-2c7b15bf009a.jpeg)

### After
![96C52AA7-796D-489F-B739-9839EA501178](https://user-images.githubusercontent.com/116835792/219503182-b1cf75d5-4fb4-4551-bea2-1dbcd5ed482c.jpeg)


## Mention
@luclemo @kstonge

