### PR TITLE
fix: SKFP-605 Case insensitive upload

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 4.15.12 0 2032-02-21
+- fix: SKFP-605 Adjust MatchTableItem interface to handle case insensitive upload searches 
+
 ### 4.15.11 0 2032-02-21
 - fix: FLUI-33 correctly reload userapi saved column
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "4.15.11",
+    "version": "4.15.12",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/UploadIds/types.ts
+++ b/packages/ui/src/components/UploadIds/types.ts
@@ -31,6 +31,7 @@ export interface MatchTableItem {
     matchTo: string;
     mappedTo: string;
     key: string;
+    value?: string;
 }
 
 export interface UnmatchTableItem {


### PR DESCRIPTION
# BUG

- closes [SKFP-605](https://d3b.atlassian.net/browse/SKFP-605)

## Description
- Add a value property to MatchTableItem to handle use cases where all other properties are necessary but cannot be used as queried value. 
- Related to https://github.com/kids-first/kf-portal-ui/pull/3682

## Screenshot
### Before
![605_before](https://user-images.githubusercontent.com/116835792/220398417-6bc1c866-96e2-4668-9ae3-6c7d717af928.png)

### After
![E948245D-4DB2-40B5-9EB6-F57BB8BE3290](https://user-images.githubusercontent.com/116835792/220398852-068057ee-aec1-423d-9c6e-1d155c1f13ea.jpeg)