### PR TITLE
fix(entitytable): FLUI-45 fix client height

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "5.4.0",
+    "version": "5.4.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Card, Space, Typography } from 'antd';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 
@@ -47,16 +47,17 @@ const EntityTable = ({
     title,
     emptyMessage = 'No data available',
 }: IEntityTable): React.ReactElement => {
-    const tableRef = useRef<HTMLDivElement>(null);
     const [scroll, setScroll] = useState<{ y: number } | undefined>(undefined);
 
-    useEffect(() => {
-        const height = tableRef.current?.clientHeight ?? 0;
-
-        if (height > 400) {
-            setScroll({ y: 400 });
-        }
-    }, [tableRef, loading, data]);
+    const tableRef = useCallback(
+        (node) => {
+            const height = node?.clientHeight ?? 0;
+            if (height > 400) {
+                setScroll({ y: 400 });
+            }
+        },
+        [loading, data],
+    );
 
     return (
         <div className={styles.container} id={id}>


### PR DESCRIPTION
# BUG 

- closes #[45](https://ferlab-crsj.atlassian.net/browse/FLUI-45)

## Description
La client height ne se déclenchait pas car la référence était null dans useEffect. useCallback semble corriger le probleme.

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/65532894/225427382-97b01966-dba8-480d-b2cc-2dfb4a44be09.png)

### After
![image](https://user-images.githubusercontent.com/65532894/225427455-b95409a2-4ce5-4be6-8a0c-fa169a41f1b8.png)



