### PR TITLE
fix(pagination): FLUI-29 FLUI-42 FLUI-39 fix searchafter

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "5.5.6",
+    "version": "5.5.7",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Header/ItemsCount/index.tsx
+++ b/packages/ui/src/components/ProTable/Header/ItemsCount/index.tsx
@@ -30,6 +30,7 @@ export const ItemsCount = ({
     const to = from + (isLastPage && hasLessThanPageSize ? total % size : size) - 1;
 
     const formatNumber = () => (dictionnary.numberFormat ? dictionnary.numberFormat(total) : total);
+
     return (
         <Space className={className}>
             {(to < size && page === 1) || total === 0 ? (

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -16,6 +16,7 @@ const Pagination = ({
     current,
     defaultViewPerQuery,
     dictionary,
+    loading,
     onChange,
     onPageChange,
     onShowSizeChange,
@@ -28,7 +29,8 @@ const Pagination = ({
     const isDisabled =
         queryConfig.searchAfter === undefined ||
         total === 0 ||
-        queryConfig.firstPageFlag?.toString() === searchAfter?.tail?.toString();
+        queryConfig.firstPageFlag?.toString() === searchAfter?.tail?.toString() ||
+        loading;
 
     return (
         <Space className={styles.pagination}>
@@ -37,10 +39,13 @@ const Pagination = ({
                 onSelect={(viewPerQuery: PaginationViewPerQuery) => {
                     setQueryConfig({
                         ...queryConfig,
+                        firstPageFlag: undefined,
+                        operations: undefined,
+                        searchAfter: undefined,
                         size: viewPerQuery,
                         sort: queryConfig.operations?.previous ? reverseSortDirection(queryConfig) : queryConfig.sort,
                     });
-
+                    onChange(1, queryConfig.size);
                     onViewQueryChange?.(viewPerQuery);
                     onShowSizeChange();
                 }}
@@ -89,7 +94,7 @@ const Pagination = ({
                 {dictionary?.pagination?.previous || 'Prev.'}
             </Button>
             <Button
-                disabled={total === 0 || total < queryConfig.size}
+                disabled={total === 0 || total < queryConfig.size || loading}
                 onClick={() => {
                     setQueryConfig({
                         ...queryConfig,

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -82,8 +82,8 @@ export const generateColumnState = <RecordType,>(
     };
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 const ProTable = <RecordType extends object & { key: string } = any>({
-    tableId,
     columns,
     pagination,
     wrapperClassName = '',
@@ -99,19 +99,29 @@ const ProTable = <RecordType extends object & { key: string } = any>({
             total: 0,
         },
         marginBtm: 12,
-        onClearSelection: () => {},
-        onColumnSortChange: () => {},
-        onSelectAllResultsChange: () => {},
-        onSelectedRowsChange: () => {},
-        onTableExportClick: () => {},
+        onClearSelection: () => {
+            // optional function when omit
+        },
+        onColumnSortChange: () => {
+            // optional function when omit
+        },
+        onSelectAllResultsChange: () => {
+            // optional function when omit
+        },
+        onSelectedRowsChange: () => {
+            // optional function when omit
+        },
+        onTableExportClick: () => {
+            // optional function when omit
+        },
     },
     initialSelectedKey = [],
     enableRowSelection = false,
     initialColumnState,
     dictionary = {},
     summaryColumns,
-    onSelectionChange,
     tableRef,
+    loading,
     ...tableProps
 }: TProTableProps<RecordType>): React.ReactElement => {
     //    const columnState = generateColumnState(initialColumnState!, columns);
@@ -123,7 +133,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
     const [selectedRowKeys, setSelectedRowKeys] = useState<any[]>(initialSelectedKey);
 
     useEffect(() => {
-        const orderedColumns = generateColumnState(initialColumnState!, columns);
+        const orderedColumns = generateColumnState(initialColumnState ?? [], columns);
         setLeftColumnsState(orderedColumns.left);
         setColumnsState(orderedColumns.dynamic);
         setRightColumnsState(orderedColumns.right);
@@ -233,6 +243,9 @@ const ProTable = <RecordType extends object & { key: string } = any>({
         return { ...column, title };
     };
 
+    const isProColumnsType = (c: ProColumnTypes<RecordType> | undefined): c is ProColumnTypes<RecordType> =>
+        !isEmpty(c);
+
     const tablePropsExtra: TPropsTablePropsExtra = {};
     if (summaryColumns) {
         tablePropsExtra.summary = () => (
@@ -258,7 +271,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                 className={tableHeaderClassName}
                 dictionary={dictionary}
                 extra={getExtraConfig()}
-                extraSpacing={headerConfig.extraSpacing!}
+                extraSpacing={headerConfig.extraSpacing}
                 hideItemsCount={headerConfig.hideItemsCount}
                 onClearSelection={() => {
                     if (headerConfig.onClearSelection) {
@@ -288,8 +301,8 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                         ?.concat(columnsState, rightColumnsState)
                         .filter(({ visible }) => visible)
                         .sort((a, b) => a.index - b.index)
-                        .map(({ key }) => columns.find((column) => column.key === key)!)
-                        .filter((column) => !isEmpty(column))
+                        .map(({ key }) => columns.find((column) => column.key === key))
+                        .filter(isProColumnsType)
                         .map(generateColumnTitle)}
                     locale={{
                         emptyText: (
@@ -332,6 +345,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                                       handleOnSelectRowsChange(selectedRowKeys, selectedRows);
 
                                       if (tableProps.rowSelection?.onChange) {
+                                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                                           // @ts-ignore
                                           tableProps.rowSelection.onChange(selectedRowKeys, selectedRows);
                                       }
@@ -358,6 +372,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                 <Pagination
                     {...(pagination as IPaginationProps)}
                     dictionary={dictionary}
+                    loading={loading ? true : false}
                     onPageChange={() => {
                         if (selectedAllResults) {
                             handleOnSelectRowsChange([], []);
@@ -367,7 +382,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                     onShowSizeChange={() => {
                         handleOnSelectRowsChange([], []);
                     }}
-                    total={tableProps.dataSource?.length || headerConfig.itemCount?.total || 0}
+                    total={headerConfig.itemCount?.total || 0}
                 />
             )}
         </Space>

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -12,6 +12,7 @@ export enum PaginationDirection {
 }
 
 export interface IPaginationProps {
+    loading: boolean;
     current: number;
     setQueryConfig: TQueryConfigCb;
     queryConfig: IQueryConfig;

--- a/packages/ui/src/components/ProTable/utils.ts
+++ b/packages/ui/src/components/ProTable/utils.ts
@@ -23,3 +23,16 @@ export const reverseSortDirection = (queryConfig: IQueryConfig): ISort[] =>
             order: sort.order === SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc,
         };
     });
+
+export const resetSearchAfterQueryConfig = (
+    queryConfig: IQueryConfig,
+    setQueryConfig: (queryConfig: IQueryConfig) => void,
+): void => {
+    setQueryConfig({
+        ...queryConfig,
+        firstPageFlag: undefined,
+        operations: undefined,
+        pageIndex: 1,
+        searchAfter: undefined,
+    });
+};


### PR DESCRIPTION
#  BUG

- closes #[29](https://ferlab-crsj.atlassian.net/browse/FLUI-29)
- closes #[39](https://ferlab-crsj.atlassian.net/browse/FLUI-39)
- closes #[42](https://ferlab-crsj.atlassian.net/browse/FLUI-42)

## Description
Un fix client doit aussi être appliqué afin de retirer le searchafter lorsqu'on modifie la query

```
  useEffect(() => {
    if (selectedKeys.length) {
      setSelectedKeys([]);
      setSelectedRows([]);
    }

    resetSearchAfterQueryConfig(
      {
        ...DEFAULT_QUERY_CONFIG,
        sort: DEFAULT_BIOSPECIMEN_QUERY_SORT,
        size:
          userInfo?.config?.data_exploration?.tables?.biospecimens?.viewPerQuery ||
          DEFAULT_PAGE_SIZE,
      },
      setQueryConfig,
    );
    setPageIndex(DEFAULT_PAGE_INDEX);

    // eslint-disable-next-line
  }, [JSON.stringify(activeQuery)]);
```

Acceptance Criterias

## Validation de Qualité
- [x] QA - Validation des critère de succès (via screenshot)


## Screenshot


https://user-images.githubusercontent.com/65532894/228635245-c32694ec-a7f7-458b-a85f-c534832a4c4e.mp4


https://user-images.githubusercontent.com/65532894/228635246-a047a4fa-7148-497c-a4d8-c538beb3bab2.mp4


https://user-images.githubusercontent.com/65532894/228635249-7114c362-300c-4323-a033-20ec9b2b447a.mp4



## Mention
@kstonge

