### PR TITLE
fix(searchafter): FLUI-59 fix next button

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "5.5.7",
+    "version": "5.5.8",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Pagination/index.tsx
+++ b/packages/ui/src/components/ProTable/Pagination/index.tsx
@@ -94,7 +94,7 @@ const Pagination = ({
                 {dictionary?.pagination?.previous || 'Prev.'}
             </Button>
             <Button
-                disabled={total === 0 || total < queryConfig.size || loading}
+                disabled={total === 0 || total < queryConfig.size || queryConfig.size * current >= total || loading}
                 onClick={() => {
                     setQueryConfig({
                         ...queryConfig,


### PR DESCRIPTION
# BUG

- closes #[59](https://ferlab-crsj.atlassian.net/browse/FLUI-59)

## Description
Filtrer le tableau pour avoir un nombre de résultat restraint (e.g. 11 résultat, viewPerQuery de 10)
Faire next
Next permet encore d'aller plus loin alors qu'il devrait être bloqué

## Screenshot
### Before
https://user-images.githubusercontent.com/65532894/229149015-46853f4d-6605-497c-be1e-60a8f2358f4e.mp4

### After

https://user-images.githubusercontent.com/65532894/229149110-f0337d64-e490-468b-8c29-99b8b787289c.mp4



## Mention
@kstonge

