### PR TITLE
feat: CQDG-215 create UserAvatar with auto color by users name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "ferlab-ui",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "golden-layout": "^2.6.0"
-      },
       "devDependencies": {
         "husky": "^4.3.6",
         "lint-staged": "^10.5.4"
@@ -460,11 +457,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/golden-layout": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-2.6.0.tgz",
-      "integrity": "sha512-sIVQCiRWOymHbVD1Aw/T9/ijbPYAVGBlgGYd1N9MRKfcyBNSpjr87Vg9nSHm+RCT8ELrvK8IJYJV0QRJuVUkCQ=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1556,11 +1548,6 @@
       "requires": {
         "pump": "^3.0.0"
       }
-    },
-    "golden-layout": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-2.6.0.tgz",
-      "integrity": "sha512-sIVQCiRWOymHbVD1Aw/T9/ijbPYAVGBlgGYd1N9MRKfcyBNSpjr87Vg9nSHm+RCT8ELrvK8IJYJV0QRJuVUkCQ=="
     },
     "has-flag": {
       "version": "4.0.0",

--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,5 +1,9 @@
+### 6.1.0 2023-04-19
+- feat: CQDG-215 create UserAvatar with auto color by user's name
+
 ### 5.5.3 2023-03-24
 - fix: FLUI-0000 support react 18.x.x
+
 ### 5.2.2 2023-03-06
 - fix: CLIN-1663 500 error when bad formatted json
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/UserAvatar/index.test.tsx
+++ b/packages/ui/src/components/UserAvatar/index.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom';
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import UserAvatar from './index';
+
+describe('UserAvatar', () => {
+    test('renders user initials when userName is provided and src is not provided', () => {
+        const userName = 'John Doe';
+        const { getByText } = render(<UserAvatar userName={userName} />);
+        const initials = getByText(/JD/);
+        expect(initials).toBeInTheDocument();
+    });
+
+    test('renders an image when src is provided', () => {
+        const src = 'https://example.com/user.jpg';
+        const { getByAltText } = render(<UserAvatar src={src} />);
+        const image = getByAltText(/UserAvatar/);
+        expect(image).toBeInTheDocument();
+        expect(image).toHaveAttribute('src', src);
+    });
+
+    test('renders a circular avatar when circle prop is true', () => {
+        const { getByTestId } = render(<UserAvatar circle />);
+        const avatar = getByTestId(/UserAvatar/);
+        expect(avatar).toHaveClass('ant-avatar-circle');
+    });
+
+    test('renders a square avatar when circle prop is false', () => {
+        const { getByTestId } = render(<UserAvatar circle={false} />);
+        const avatar = getByTestId(/UserAvatar/);
+        expect(avatar).not.toHaveClass('ant-avatar-circle');
+    });
+});

--- a/packages/ui/src/components/UserAvatar/index.tsx
+++ b/packages/ui/src/components/UserAvatar/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { CSSProperties } from 'react';
+import { Avatar } from 'antd';
+import { AvatarSize } from 'antd/lib/avatar/SizeContext';
+
+const getStringColor = (string: string): string => {
+    let hash = 0;
+    if (string.length > 0) {
+        for (let i = 0; i < string.length; i += 1) {
+            hash = string.charCodeAt(i) + ((hash << 5) - hash);
+            hash &= hash;
+        }
+    }
+    return `hsl(${hash % 360}, 75%, 50%)`;
+};
+
+const getInitials = (name = ''): string => {
+    const initials = name.trim().split(/\s+/gu) || [];
+    let output = [...(initials.shift() || '')][0];
+    if (initials.length > 0) {
+        output += [...(initials.pop() || '')][0];
+    }
+    return output?.toUpperCase();
+};
+
+export interface IUserAvatarProps {
+    alt?: string;
+    circle?: boolean;
+    className?: string;
+    height?: number;
+    size?: AvatarSize;
+    src?: string | null;
+    style?: CSSProperties;
+    userName?: string;
+    width?: number;
+    icon?: React.ReactNode;
+    gap?: number;
+}
+
+const UserAvatar = ({
+    alt = 'UserAvatar',
+    circle = true,
+    className = '',
+    height = 100,
+    size = 100,
+    src = '',
+    style = {},
+    userName = '',
+    width = 100,
+    icon,
+    gap = 1,
+}: IUserAvatarProps): React.ReactElement => {
+    if (src) {
+        return (
+            <img
+                alt={alt}
+                className={className}
+                height={height}
+                src={src}
+                style={circle ? { borderRadius: '50%', ...style } : style}
+                width={width}
+            />
+        );
+    }
+    return (
+        <Avatar
+            alt={alt}
+            className={className}
+            gap={gap}
+            icon={icon}
+            shape={circle ? 'circle' : 'square'}
+            size={size}
+            style={{ backgroundColor: getStringColor(userName), verticalAlign: 'middle', ...style }}
+        >
+            {getInitials(userName)}
+        </Avatar>
+    );
+};
+
+export default UserAvatar;

--- a/packages/ui/src/components/UserAvatar/index.tsx
+++ b/packages/ui/src/components/UserAvatar/index.tsx
@@ -48,7 +48,7 @@ const UserAvatar = ({
     userName = '',
     width = 100,
     icon,
-    gap = 1,
+    gap = 4,
 }: IUserAvatarProps): React.ReactElement => {
     if (src) {
         return (

--- a/packages/ui/src/components/UserAvatar/index.tsx
+++ b/packages/ui/src/components/UserAvatar/index.tsx
@@ -5,7 +5,7 @@ import { AvatarSize } from 'antd/lib/avatar/SizeContext';
 
 const getStringColor = (string: string): string => {
     let hash = 0;
-    if (string.length > 0) {
+    if (string.length) {
         for (let i = 0; i < string.length; i += 1) {
             hash = string.charCodeAt(i) + ((hash << 5) - hash);
             hash &= hash;
@@ -17,7 +17,7 @@ const getStringColor = (string: string): string => {
 const getInitials = (name = ''): string => {
     const initials = name.trim().split(/\s+/gu) || [];
     let output = [...(initials.shift() || '')][0];
-    if (initials.length > 0) {
+    if (initials.length) {
         output += [...(initials.pop() || '')][0];
     }
     return output?.toUpperCase();
@@ -66,6 +66,7 @@ const UserAvatar = ({
         <Avatar
             alt={alt}
             className={className}
+            data-testid={alt}
             gap={gap}
             icon={icon}
             shape={circle ? 'circle' : 'square'}

--- a/storybook/stories/Components/UserAvatar/UserAvatar.stories.tsx
+++ b/storybook/stories/Components/UserAvatar/UserAvatar.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import UserAvatar from '@ferlab/ui/components/UserAvatar';
+import UserAvatar, { IUserAvatarProps } from '@ferlab/ui/components/UserAvatar';
 
 export default {
     title: "@ferlab/Components/UserAvatar",
@@ -43,21 +43,33 @@ export default {
     },
 } as Meta
 
-export const UserAvatarStory = () => (
+export const UserAvatarStory = ({
+    alt = 'UserAvatar',
+    circle = true,
+    className = undefined,
+    height = undefined,
+    size = undefined,
+    src = undefined,
+    style = undefined,
+    userName = 'John Doe',
+    width = undefined,
+    icon = undefined,
+    gap = 4,
+}: IUserAvatarProps) => (
     <>
         <h3>UserAvatar Story</h3>
         <UserAvatar
-            alt={'UserAvatar'}
-            circle
-            className={undefined}
-            height={undefined}
-            size={24}
-            src={undefined}
-            style={undefined}
-            userName='John Doe'
-            width={undefined}
-            icon={undefined}
-            gap={4}
+            alt={alt}
+            circle={circle}
+            className={className}
+            height={height}
+            size={size}
+            src={src}
+            style={style}
+            userName={userName}
+            width={width}
+            icon={icon}
+            gap={gap}
         />
     </>
 );

--- a/storybook/stories/Components/UserAvatar/UserAvatar.stories.tsx
+++ b/storybook/stories/Components/UserAvatar/UserAvatar.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import UserAvatar from '@ferlab/ui/components/UserAvatar';
+
+export default {
+    title: "@ferlab/Components/UserAvatar",
+    component: UserAvatar,
+    decorators: [(Story) => <Story />],
+    argTypes: {
+        alt: {
+            control: 'text'
+        },
+        circle: {
+            control: 'boolean'
+        },
+        className: {
+            control: 'text'
+        },
+        height: {
+            control: 'number'
+        },
+        size: {
+            control: 'text'
+        },
+        src: {
+            control: 'text'
+        },
+        style: {
+            control: 'object'
+        },
+        userName: {
+            control: 'text'
+        },
+        width: {
+            control: 'number'
+        },
+        icon: {
+            control: 'text'
+        },
+        gap: {
+            control: 'number'
+        },
+    },
+} as Meta
+
+export const UserAvatarStory = () => (
+    <>
+        <h3>UserAvatar Story</h3>
+        <UserAvatar
+            alt={'UserAvatar'}
+            circle
+            className={undefined}
+            height={undefined}
+            size={24}
+            src={undefined}
+            style={undefined}
+            userName='John Doe'
+            width={undefined}
+            icon={undefined}
+            gap={4}
+        />
+    </>
+);
+


### PR DESCRIPTION
# [FEATURE] create UserAvatar

- closes #3242

## Description

Simple way to create users avatar based on their names, google like.
If `src` is defined then display proper image.

Acceptance Criterias

## Validation de Qualité


- [x] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [x] Design/UI - Validation du respect du design/theme

## Screenshot
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/15524246/233172995-873a115e-46df-49a4-9ac0-2d34b78bb48f.png">

[![image](https://user-images.githubusercontent.com/15524246/233173046-f02170de-c544-4f6d-955a-695aa2015bea.png)](https://files.slack.com/files-pri/TFDLDE8J3-F054QV11ZCG/image.png)

[![image](https://user-images.githubusercontent.com/15524246/233173097-71e71724-a266-4c38-a7f2-0bfcc3dec007.png)](https://files.slack.com/files-pri/TFDLDE8J3-F0543Q2G85A/image.png)


## Mention
@luclemo @kstonge

