### PR TITLE
fix(resizablegrid): SKFP-664 fix drag handle and menu behavior

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.module.scss
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.module.scss
@@ -1,4 +1,3 @@
-
 .popover {
   div[class$="-inner-content"] {
     padding: 12px;

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
@@ -12,6 +12,7 @@ type TResizableItem = {
 
 type TResizableItemSelector = {
     items: TResizableItem[];
+    defaultItems: TResizableItem[];
     onReset: () => void;
     onChange: (id: string, checkbox: boolean) => void;
     dictionary?: {
@@ -19,7 +20,13 @@ type TResizableItemSelector = {
     };
 };
 
-const ResizableItemSelector = ({ dictionary, items, onChange, onReset }: TResizableItemSelector): JSX.Element => (
+const ResizableItemSelector = ({
+    defaultItems,
+    dictionary,
+    items,
+    onChange,
+    onReset,
+}: TResizableItemSelector): JSX.Element => (
     <Popover
         align={{ offset: [-9, 0] }}
         content={
@@ -39,7 +46,13 @@ const ResizableItemSelector = ({ dictionary, items, onChange, onReset }: TResiza
                         ))}
                     </Space>
                     <div className={styles.resetWrapper}>
-                        <Button className={styles.reset} onClick={onReset} size="small" type="link">
+                        <Button
+                            className={styles.reset}
+                            disabled={JSON.stringify(items) === JSON.stringify(defaultItems)}
+                            onClick={onReset}
+                            size="small"
+                            type="link"
+                        >
                             {dictionary?.columnSelector?.reset || 'Reset'}
                         </Button>
                     </div>
@@ -50,7 +63,7 @@ const ResizableItemSelector = ({ dictionary, items, onChange, onReset }: TResiza
         placement="bottomLeft"
         trigger="click"
     >
-        <Tooltip title={dictionary?.columnSelector?.tooltips?.columns || 'Columns'}>
+        <Tooltip title={dictionary?.chartsSelector?.tooltips?.charts || 'Charts'}>
             <Button icon={<SettingOutlined />} size="small" type="text"></Button>
         </Tooltip>
     </Popover>

--- a/packages/ui/src/layout/ResizableGridLayout/index.module.scss
+++ b/packages/ui/src/layout/ResizableGridLayout/index.module.scss
@@ -1,3 +1,5 @@
+@import "theme.template";
+
 .wrapper {
   width: 100%;
 
@@ -11,5 +13,16 @@
   .grid {
     width: 100%;
     height: 100%;
+  }
+}
+
+:global(.react-grid-item > .react-resizable-handle ) {
+  width: 16px;
+  height: 16px;
+
+  &::after {
+    border-color: $grid-layout-resize-color;
+    width: 8px;
+    height: 8px;
   }
 }

--- a/packages/ui/src/layout/ResizableGridLayout/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/index.tsx
@@ -172,11 +172,17 @@ const ResizableGridLayout = ({
         label: title,
         value: hidden === undefined ? true : !hidden,
     }));
+    const defaultResizableItemsList = defaultLayouts.map(({ hidden, id, title }) => ({
+        id,
+        label: title,
+        value: hidden === undefined ? true : !hidden,
+    }));
 
     return (
         <Space className={styles.wrapper} direction="vertical">
             <div className={styles.graphSelector}>
                 <ResizableItemSelector
+                    defaultItems={defaultResizableItemsList}
                     items={resizableItemsList}
                     onChange={(targetId, checked) => {
                         onConfigUpdate(serialize(updateConfig(configs, targetId, 'hidden', !checked)));
@@ -192,6 +198,7 @@ const ResizableGridLayout = ({
                         className="layout"
                         cols={{ lg: 16, md: 12, sm: 10, xs: 6, xxs: 4 }}
                         containerPadding={[0, 0]}
+                        draggableHandle=".ant-card-head"
                         layouts={responsiveDefaultLayouts}
                         margin={[12, 12]}
                         maxRows={10}

--- a/packages/ui/src/view/v2/GridCard/Gridcard.module.scss
+++ b/packages/ui/src/view/v2/GridCard/Gridcard.module.scss
@@ -41,6 +41,7 @@ $padding-side-and-bottom: 24px;
       padding: 0;
 
       div[class$="-head"] {
+        cursor: move;
         div[class$="-head-title"] {
           padding: 2px 0;
         }

--- a/packages/ui/themes/default/_colors.scss
+++ b/packages/ui/themes/default/_colors.scss
@@ -91,3 +91,5 @@ $error-color: $red-8;
 $highlight-color: $magenta-6;
 $normal-color: $gray-5;
 $border-color-split: $gray-4;
+
+$grid-layout-resize-color: $gray-7;


### PR DESCRIPTION
#  BUG

- closes #[664](https://d3b.atlassian.net/browse/SKFP-664)

## Description

1. Le Click Target du resizer devrait être 16x16
![Selection_001](https://user-images.githubusercontent.com/65532894/234357494-0b2fbe2b-dfc4-43bf-8b02-2d8b51645fca.png)

2. L’icône du resizer devrait être 8x8
![Selection_002](https://user-images.githubusercontent.com/65532894/234357524-7939cf33-37ac-41ca-8433-8a045070fbf0.png)

![Selection_003](https://user-images.githubusercontent.com/65532894/234357574-49d4bd3a-1503-4303-a3e6-bd600df5e6b9.png)

3. Griser le bouton Reset lorsqu’on est à l’état initial

https://user-images.githubusercontent.com/65532894/234357692-8c96e3c4-2964-4bf8-a1b0-55b3a33cf419.mp4


4. Renommer le tooltip de la personnalisation « Charts »
![Selection_005](https://user-images.githubusercontent.com/65532894/234357722-f9c4c8c2-a6bd-4e72-9a5b-96ace12b29dc.png)

5. Limiter l’action du drag au header des cartes, les fonctionnalités des graphiques fonctionnent mal


https://user-images.githubusercontent.com/65532894/234357803-6915b8f8-7287-4ccf-a693-58e9315ab1bb.mp4


6. Modifier le curseur lors d’un hover sur toute la header des cartes (pas juste sur les 6 p’tits points)


https://user-images.githubusercontent.com/65532894/234357853-dd917387-c423-4e38-b872-daf03a460964.mp4



## Mention
@luclemo @kstonge

