### PR TITLE
fix(resizableGrid): SKFP-664 improve reset behavior to support move a…

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "6.1.2",
+    "version": "6.1.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
@@ -12,7 +12,7 @@ type TResizableItem = {
 
 type TResizableItemSelector = {
     items: TResizableItem[];
-    defaultItems: TResizableItem[];
+    isPristine: boolean;
     onReset: () => void;
     onChange: (id: string, checkbox: boolean) => void;
     dictionary?: {
@@ -21,8 +21,8 @@ type TResizableItemSelector = {
 };
 
 const ResizableItemSelector = ({
-    defaultItems,
     dictionary,
+    isPristine,
     items,
     onChange,
     onReset,
@@ -48,7 +48,7 @@ const ResizableItemSelector = ({
                     <div className={styles.resetWrapper}>
                         <Button
                             className={styles.reset}
-                            disabled={JSON.stringify(items) === JSON.stringify(defaultItems)}
+                            disabled={isPristine}
                             onClick={onReset}
                             size="small"
                             type="link"

--- a/packages/ui/src/layout/ResizableGridLayout/index.test.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/index.test.tsx
@@ -1,17 +1,15 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 
 import GridCard, { GridCardHeader } from '../../view/v2/GridCard';
 
-import ResizableGridLayout, {
+import {
     deserialize,
     hasLayout,
-    IResizableGridLayoutConfig,
+    isPrisitine,
     serialize,
     serializeConfigToLayouts,
     serializeLayoutsToConfig,
-    TSerializedResizableGridLayoutConfig,
     updateConfig,
 } from '.';
 
@@ -35,123 +33,6 @@ const GridCardItem = ({ id }: { id: string }) => (
         title={<GridCardHeader id={id} title={`GridCard Header ${id}`} withHandle />}
     />
 );
-
-const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
-    {
-        base: {
-            h: 3,
-            minH: 3,
-            minW: 3,
-            w: 6,
-            x: 0,
-            y: 0,
-        },
-        component: <GridCardItem id="card_1" />,
-        id: 'card_1',
-        title: 'Card 1',
-    },
-    {
-        base: {
-            h: 3,
-            minH: 3,
-            minW: 3,
-            w: 5,
-            x: 6,
-            y: 0,
-        },
-        component: <GridCardItem id="card_2" />,
-        id: 'card_2',
-        title: 'Card 2',
-    },
-    {
-        base: {
-            h: 4,
-            minH: 3,
-            minW: 3,
-            w: 6,
-            x: 0,
-            y: 3,
-        },
-        component: <GridCardItem id="card_3" />,
-        id: 'card_3',
-        title: 'Card 3',
-    },
-    {
-        base: {
-            h: 4,
-            minH: 3,
-            minW: 3,
-            w: 5,
-            x: 7,
-            y: 3,
-        },
-        component: <GridCardItem id="card_4" />,
-        id: 'card_4',
-        title: 'Card 4',
-    },
-];
-
-// card_3, card_4 are hidden
-const getSerializedLayout = (): TSerializedResizableGridLayoutConfig[] => [
-    {
-        base: {
-            h: 4,
-            minH: 4,
-            minW: 4,
-            w: 4,
-            x: 4,
-            y: 0,
-        },
-        id: 'card_1',
-        md: {
-            h: 4,
-            minH: 4,
-            minW: 4,
-            w: 4,
-            x: 0,
-            y: 0,
-        },
-        title: 'Card 1',
-    },
-    {
-        base: {
-            h: 4,
-            minH: 4,
-            minW: 4,
-            w: 8,
-            x: 8,
-            y: 0,
-        },
-        id: 'card_2',
-        title: 'Card 2',
-    },
-    {
-        base: {
-            h: 4,
-            minH: 3,
-            minW: 3,
-            w: 6,
-            x: 0,
-            y: 4,
-        },
-        hidden: true,
-        id: 'card_3',
-        title: 'Card 3',
-    },
-    {
-        base: {
-            h: 4,
-            minH: 3,
-            minW: 3,
-            w: 5,
-            x: 6,
-            y: 4,
-        },
-        hidden: true,
-        id: 'card_4',
-        title: 'Card 4',
-    },
-];
 
 describe('ResizableGridLayout', () => {
     test('make sure serialize function return TSerializedResizableGridLayoutConfig[]', () => {
@@ -555,5 +436,75 @@ describe('ResizableGridLayout', () => {
                 title: 'Card 1',
             },
         ]);
+    });
+
+    test('isPristine can compare two IResizableGridLayoutConfig', () => {
+        const defaultConfigs = [
+            {
+                base: {
+                    h: 3,
+                    minh: 3,
+                    minw: 3,
+                    w: 6,
+                    x: 0,
+                    y: 0,
+                },
+                component: <GridCardItem id="card_1" />,
+                id: 'card_1',
+                md: {
+                    h: 4,
+                    w: 6,
+                    x: 6,
+                },
+                title: 'card 1',
+            },
+        ];
+
+        const configs = [
+            {
+                base: {
+                    h: 3,
+                    minh: 3,
+                    minw: 3,
+                    w: 6,
+                    x: 0,
+                    y: 0,
+                },
+                component: <GridCardItem id="card_1" />,
+                id: 'card_1',
+                md: {
+                    h: 4,
+                    moved: false, // default value added by RCL
+                    static: false, // default value added by RCL
+                    w: 6,
+                    x: 6,
+                },
+                title: 'card 1',
+            },
+        ];
+
+        const configs2 = [
+            {
+                base: {
+                    h: 3,
+                    minh: 3,
+                    minw: 3,
+                    w: 6,
+                    x: 0,
+                    y: 0,
+                },
+                component: <GridCardItem id="card_1" />,
+                id: 'card_1',
+                md: {
+                    h: 5, // changed
+                    w: 6,
+                    x: 10, // changed
+                },
+                title: 'card 1',
+            },
+        ];
+
+        expect(isPrisitine(defaultConfigs, configs)).toBeTruthy();
+        expect(isPrisitine(defaultConfigs, configs2)).toBeFalsy();
     });
 });


### PR DESCRIPTION
…nd resize

# BUG 

- closes #[664](https://d3b.atlassian.net/browse/SKFP-664)

## Description
3. Griser le bouton Reset lorsqu’on est à l’état initial
Le premier fix ne prenait en considération que si l'on cache un élément, j'ai amélioré pour aussi permettre un reset lorsqu'on déplace ou resize un élément

Acceptance Criterias

## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot

https://user-images.githubusercontent.com/65532894/234654827-b9b03728-7a93-4c7c-b6cb-950c1431fb17.mp4



## Mention
@luclemo @kstonge

