### PR TITLE
fix(filter): SJIP use key_as_string instead of key for boolean

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "6.0.0",
+    "version": "6.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "6.0.0",
+            "version": "6.1.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "6.1.3",
+    "version": "7.0.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/data/arranger/formatting.ts
+++ b/packages/ui/src/data/arranger/formatting.ts
@@ -14,21 +14,6 @@ export const keyEnhance = (key: string, s: string = ArrangerValues.noData): stri
     switch (key) {
         case ArrangerValues.missing:
             return s;
-        case ArrangerValues.true:
-            return AggregateValues.true;
-        case ArrangerValues.false:
-            return AggregateValues.false;
-        default:
-            return key;
-    }
-};
-
-export const keyEnhanceBooleanOnly = (key: string) => {
-    switch (key) {
-        case ArrangerValues.true:
-            return AggregateValues.true;
-        case ArrangerValues.false:
-            return AggregateValues.false;
         default:
             return key;
     }


### PR DESCRIPTION
# BUG 

- closes #[389](https://d3b.atlassian.net/browse/SJIP-389)

## Description
Actuellement, on cast chaque valeur 0 ou 1 en boolean, ce qui cause des conflits au niveau des chromosomes. 

## Solution & Guide de migration
1 - Côté client,  Ajouter key_as_string dans la requêtre des aggregas `src/graphql/queries.ts`
```typescript
const generateAggregations = (extendedMappingFields: TExtendedMapping[]) => {
  const aggs = extendedMappingFields.map((f) => {
    if (['keyword', 'id'].includes(f.type)) {
      return (
        dotToUnderscore(f.field) +
        ' {\n     buckets {\n      key\n        key_as_string\n        doc_count\n    }\n  }'
      );
    } else if (['long', 'float', 'integer', 'date'].includes(f.type)) {
      return dotToUnderscore(f.field) + '{\n    stats {\n  max\n   min\n    }\n    }';
    } else if (['boolean'].includes(f.type)) {
      return (
        dotToUnderscore(f.field) +
        ' {\n      buckets {\n       key\n        key_as_string\n       doc_count\n     }\n    }'
      );
    } else {
      return '';
    }
  });
  return aggs.join(' ');
};
```
2 - Côté client, mettre à jour la fonction getFilters `src/graphql/utils/Filters.tsx`
```typescript
export const getFilters = (aggregations: TAggregations | null, key: string): IFilter[] => {
  if (!aggregations || !key) return [];

  if (isTermAgg(aggregations[key])) {
    return aggregations[key!].buckets
      .map((f: any) => {
        const enhanceKey = f.key_as_string ?? f.key;
        const translatedKey = translateWhenNeeded(key, enhanceKey);
        const name = translatedKey ? translatedKey : enhanceKey;

        return {
          data: {
            count: f.doc_count,
            key: enhanceKey,
          },
          id: f.key,
          name: transformNameIfNeeded(key, name),
        };
      })
      .filter((f: any) => !(f.name === ''));
  } else if (aggregations[key]?.stats) {
    return [
      {
        data: { max: 1, min: 0 },
        id: key,
        name: translateWhenNeeded(key, key),
      },
    ];
  }
  return [];
};
```
3 - Mettre à jour ferlab-ui en version 7.

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/65532894/235473891-7fd9c44f-4e6e-40ed-9c87-f64933cef714.png)
![image](https://user-images.githubusercontent.com/65532894/235474014-ec3af022-674d-4a7c-9ab3-4ea057430769.png)


### After
![image](https://user-images.githubusercontent.com/65532894/235473926-027a6563-6487-410d-8f6f-dedfa59226be.png)
![image](https://user-images.githubusercontent.com/65532894/235473968-1f22cdc2-9034-4d68-9ed6-7f93229802ac.png)


## Mention
@luclemo @kstonge

