### PR TITLE
fix(protable): SJIP-413 fix loading props regression

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -304,6 +304,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                         .map(({ key }) => columns.find((column) => column.key === key))
                         .filter(isProColumnsType)
                         .map(generateColumnTitle)}
+                    loading={loading}
                     locale={{
                         emptyText: (
                             <Empty description={dictionary.table?.emptyText || 'No available data'} size="mini" />


### PR DESCRIPTION
#  BUG 

- closes #[413](https://d3b.atlassian.net/browse/SJIP-413)

## Description
Vue que loading a été déconstruit, il n'était plus envoyere à Protable

## Screenshot
![image](https://user-images.githubusercontent.com/65532894/236907637-cbcd7589-2e86-4c1a-ae47-279d5b0abede.png)
