### PR TITLE
feat(entity): SJIP-423 add table extra and redirect link

### DIFF
--- a/packages/ui/src/components/Collapse/index.tsx
+++ b/packages/ui/src/components/Collapse/index.tsx
@@ -24,7 +24,7 @@ const Collapse = ({
     size = 'default',
     theme = 'light',
     ...rest
-}: TCollapseProps) => (
+}: TCollapseProps): JSX.Element => (
     <AntCollapse
         {...rest}
         bordered={isUndefined(rest.bordered) ? !headerBorderOnly : rest.bordered && !headerBorderOnly}
@@ -53,7 +53,7 @@ const Collapse = ({
     />
 );
 
-export const CollapsePanel = (props: TCollapsePanelProps) => (
+export const CollapsePanel = (props: TCollapsePanelProps): JSX.Element => (
     <AntCollapse.Panel {...props} className={cx(styles.fuiCollapsePanel, props.className)}>
         {props.children}
     </AntCollapse.Panel>

--- a/packages/ui/src/pages/EntityPage/EntityDescriptions/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityDescriptions/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Card, Descriptions, Space, Typography } from 'antd';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from '../../../common/constants';
@@ -13,6 +13,7 @@ export interface IEntityDescriptions {
     descriptions: IEntityDescriptionsItem[];
     loading: boolean;
     title?: string;
+    titleExtra?: ReactNode[];
     header: string;
     subheader?: React.ReactNode;
 }
@@ -30,6 +31,7 @@ const EntityDescriptions: React.FC<IEntityDescriptions> = ({
     loading,
     subheader,
     title,
+    titleExtra,
 }) => (
     <div className={styles.container} id={id}>
         {title && (
@@ -38,7 +40,7 @@ const EntityDescriptions: React.FC<IEntityDescriptions> = ({
             </Title>
         )}
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} header={header} key="1">
+            <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
                 <Card className={styles.card} loading={loading}>
                     <Space className={styles.content} direction="vertical" size={0}>
                         {subheader}

--- a/packages/ui/src/pages/EntityPage/EntityExpandableTableMultiple/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityExpandableTableMultiple/index.tsx
@@ -25,6 +25,7 @@ const EntityExpandableTableMultiple = ({
     loading,
     tables = [],
     title,
+    titleExtra,
 }: IEntityExpandableTableMultiple): React.ReactElement => (
     <div className={styles.container} id={id}>
         {title && (
@@ -33,7 +34,7 @@ const EntityExpandableTableMultiple = ({
             </Title>
         )}
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} header={header} key="1">
+            <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
                 <Card className={styles.card} loading={loading}>
                     <Space align="start" className={styles.content} direction={direction} size={12}>
                         {tables.length > 0 ? (

--- a/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { ReactNode, useCallback, useState } from 'react';
 import { Card, Space, Typography } from 'antd';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 
@@ -28,6 +28,7 @@ export interface IEntityTable {
     loading: boolean;
     size?: SizeType;
     title?: string;
+    titleExtra?: ReactNode[];
     summaryColumns?: TProTableSummary[];
     emptyMessage?: string;
 }
@@ -45,6 +46,7 @@ const EntityTable = ({
     size = 'small',
     summaryColumns = [],
     title,
+    titleExtra,
     emptyMessage = 'No data available',
 }: IEntityTable): React.ReactElement => {
     const [scroll, setScroll] = useState<{ y: number } | undefined>(undefined);
@@ -67,7 +69,7 @@ const EntityTable = ({
                 </Title>
             )}
             <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-                <CollapsePanel className={styles.panel} header={header} key="1">
+                <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
                     <Card className={styles.card} loading={loading}>
                         {!loading && data.length ? (
                             <ProTable

--- a/packages/ui/src/pages/EntityPage/EntityTableMultiple/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTableMultiple/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Card, Space, Typography } from 'antd';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 
@@ -13,6 +13,7 @@ export interface IEntityTableMultiple {
     id: string;
     header: React.ReactNode;
     title?: string;
+    titleExtra?: ReactNode[];
     loading: boolean;
     direction?: 'horizontal' | 'vertical';
     tables: {
@@ -34,6 +35,7 @@ const EntityTableMultiple = ({
     loading,
     tables = [],
     title,
+    titleExtra,
 }: IEntityTableMultiple): React.ReactElement => (
     <div className={styles.container} id={id}>
         {title && (
@@ -42,7 +44,7 @@ const EntityTableMultiple = ({
             </Title>
         )}
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} header={header} key="1">
+            <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
                 <Card className={styles.card} loading={loading}>
                     <Space align="start" className={styles.content} direction={direction} size={12}>
                         {tables.map(

--- a/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.module.scss
+++ b/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.module.scss
@@ -1,0 +1,14 @@
+@import "theme.template";
+
+.link {
+  font-size: 12px;
+
+  .content {
+    text-decoration: underline;
+  }
+}
+
+.icon {
+  color: $link-base-color;
+  font-size: 14px;
+}

--- a/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Space } from 'antd';
+
+import styles from './index.module.scss';
+
+type TEntityTableRedirectLink = {
+    to: string;
+    onClick?: () => void;
+    children: ReactNode;
+    icon?: ReactNode;
+};
+
+const EntityTableRedirectLink = (props: TEntityTableRedirectLink): JSX.Element => (
+    <Link className={styles.link} {...props}>
+        <Space size={4}>
+            <span className={styles.content}>{props.children}</span>
+            <span className={styles.icon}>{props.icon}</span>
+        </Space>
+    </Link>
+);
+
+export default EntityTableRedirectLink;

--- a/packages/ui/src/pages/EntityPage/index.tsx
+++ b/packages/ui/src/pages/EntityPage/index.tsx
@@ -11,6 +11,7 @@ import EntityPublicCohortTable from './EntityPublicCohortTable';
 import EntitySummary from './EntitySummary';
 import EntityTable, { IEntityTable } from './EntityTable';
 import EntityTableMultiple, { IEntityTableMultiple } from './EntityTableMultiple';
+import EntityTableRedirectLink from './EntityTableRedirectLink';
 import EntityTitle, { IEntityTitle } from './EntityTitle';
 
 export {
@@ -24,6 +25,7 @@ export {
     EntitySummary,
     EntityTable,
     EntityTableMultiple,
+    EntityTableRedirectLink,
     EntityTitle,
     HpoConditionCell,
     IEntityDescriptions,

--- a/packages/ui/themes/default/_theme.template.scss
+++ b/packages/ui/themes/default/_theme.template.scss
@@ -140,6 +140,9 @@ $empty-content-mini-padding: 30px 0;
 $empty-content-default-padding: 50px 0;
 $empty-content-large-padding: 50px 0;
 
+// link
+$link-base-color: $blue-8;
+
 // Collapse
 $collapse-light-background-color: white;
 $collapse-shade-background-color: #f8fafc;

--- a/storybook/stories/Pages/EntityPage/EntityExpandableTableMultiple.stories.tsx
+++ b/storybook/stories/Pages/EntityPage/EntityExpandableTableMultiple.stories.tsx
@@ -37,6 +37,9 @@ export const BasicExpandableTableMultiple = EntityExpandableTableMultipleStory.b
 BasicExpandableTableMultiple.args = {
     id: "ID",
     title: "Title",
+    titleExtra: [
+        <span>View in data exploration</span>,
+    ],
     header: <>Header</>,
     loading: false,
     tables: [

--- a/storybook/stories/Pages/EntityPage/EntityTable.stories.tsx
+++ b/storybook/stories/Pages/EntityPage/EntityTable.stories.tsx
@@ -94,6 +94,9 @@ BasicEntityTable.args = {
     loading: false,
     size: "small",
     title: "Title",
+    titleExtra: [
+        <span>View in data exploration</span>,
+    ],
     emptyMessage: "No data available",
 };
 

--- a/storybook/stories/Pages/EntityPage/EntityTableMultiple.stories.tsx
+++ b/storybook/stories/Pages/EntityPage/EntityTableMultiple.stories.tsx
@@ -35,6 +35,9 @@ export const BasicTableMultiple = EntityTableMultipleStory.bind({});
 BasicTableMultiple.args = {
     id: "ID",
     title: "Title",
+    titleExtra: [
+        <span>View in data exploration</span>,
+    ],
     header: <>Header</>,
     loading: false,
     tables: [


### PR DESCRIPTION
#  FEATURE

- closes #[423](https://d3b.atlassian.net/browse/SJIP-423)

## Description
 Similar to the Statistic buttons that are used to redirect to the Data Exploration, we will add a button “View in data exploration” on the right side of the table title for the respective entities. The filter to the Data Exploration page will be the same as the filters in the statistic button for the respective entity. 

Participant Entity tables:

Biospecimen (query = Participant ID, tab = Biospecimens)

Data File (query = Participant ID, tab = Data Files)

File Entity tables:

Participant / Sample  (query = File ID, tab = Participants)

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/7cf8b818-8e92-480d-8a6e-18d2a58e7e71)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/8eced0bf-84dd-43b0-aa08-e03e5354713e)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/ce282882-576f-4a58-880c-786b1b36d2c0)


## Mention
@luclemo @kstonge

