### PR TITLE
feat(entity): SJIP-414 add total in panel header

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.2.0",
+    "version": "7.3.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityExpandableTableMultiple/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityExpandableTableMultiple/index.tsx
@@ -24,6 +24,7 @@ const EntityExpandableTableMultiple = ({
     id,
     loading,
     tables = [],
+    total = 0,
     title,
     titleExtra,
 }: IEntityExpandableTableMultiple): React.ReactElement => (
@@ -34,7 +35,16 @@ const EntityExpandableTableMultiple = ({
             </Title>
         )}
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
+            <CollapsePanel
+                className={styles.panel}
+                extra={titleExtra}
+                header={
+                    <Space size={2}>
+                        {header} {total > 0 && <span>({total})</span>}
+                    </Space>
+                }
+                key="1"
+            >
                 <Card className={styles.card} loading={loading}>
                     <Space align="start" className={styles.content} direction={direction} size={12}>
                         {tables.length > 0 ? (

--- a/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTable/index.tsx
@@ -29,6 +29,7 @@ export interface IEntityTable {
     size?: SizeType;
     title?: string;
     titleExtra?: ReactNode[];
+    total?: number;
     summaryColumns?: TProTableSummary[];
     emptyMessage?: string;
 }
@@ -47,6 +48,7 @@ const EntityTable = ({
     summaryColumns = [],
     title,
     titleExtra,
+    total = 0,
     emptyMessage = 'No data available',
 }: IEntityTable): React.ReactElement => {
     const [scroll, setScroll] = useState<{ y: number } | undefined>(undefined);
@@ -69,7 +71,16 @@ const EntityTable = ({
                 </Title>
             )}
             <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-                <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
+                <CollapsePanel
+                    className={styles.panel}
+                    extra={titleExtra}
+                    header={
+                        <Space size={2}>
+                            {header} {total > 0 && <span>({total})</span>}
+                        </Space>
+                    }
+                    key="1"
+                >
                     <Card className={styles.card} loading={loading}>
                         {!loading && data.length ? (
                             <ProTable

--- a/packages/ui/src/pages/EntityPage/EntityTableMultiple/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTableMultiple/index.tsx
@@ -26,6 +26,7 @@ export interface IEntityTableMultiple {
         initialColumnState?: TColumnStates;
         size?: SizeType;
     }[];
+    total?: number;
 }
 
 const EntityTableMultiple = ({
@@ -36,6 +37,7 @@ const EntityTableMultiple = ({
     tables = [],
     title,
     titleExtra,
+    total = 0,
 }: IEntityTableMultiple): React.ReactElement => (
     <div className={styles.container} id={id}>
         {title && (
@@ -44,7 +46,16 @@ const EntityTableMultiple = ({
             </Title>
         )}
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
-            <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
+            <CollapsePanel
+                className={styles.panel}
+                extra={titleExtra}
+                header={
+                    <Space size={2}>
+                        {header} {total > 0 && <span>({total})</span>}
+                    </Space>
+                }
+                key="1"
+            >
                 <Card className={styles.card} loading={loading}>
                     <Space align="start" className={styles.content} direction={direction} size={12}>
                         {tables.map(


### PR DESCRIPTION
#  FEATURE 
- closes #[414](https://d3b.atlassian.net/browse/SJIP-414)

## Description
Goal:  Add number of total row items per table and place it beside the respective Table titles. 

This applies to the Diagnosis, Phenotype, Biospecimen Data File in Participant Entity page. 

This applies to the Participant / Sample table in the File Entity page

In the case of Data files table, since the files are not enumerated per row, take the total number of files associated with the Entity. 

For CQDG, There is an additional table that would need this feature, Files Generated by the Analysis, in the File Entity page which doesn’t appear in KF/INCLUDE.

Do not indicate the number “0” beside the table title if there is no data in the table.

E.g.  Diagnosis (5)


If the participant has 5 unique diagnoses (row level), then indicate in the Table title: Diagnosis (5)


Acceptance Criterias

## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/b986c282-9388-4045-adfe-058b0fb90917)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/8b3f9b31-012b-4645-964b-8f8054d2cd45)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/54bd60a4-5a28-4392-a077-e6fa03feee0b)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/01c6e5fe-da9b-4660-8cec-bf328cc36e22)



## Mention
@luclemo @kstonge

