### PR TITLE
feat(resizableGrid): SKFP-698 add download graph data

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -20,6 +20,7 @@
                 "classnames": "^2.2.6",
                 "command-line-args": "^5.1.1",
                 "cross-spawn": "^7.0.3",
+                "d3-svg-to-png": "^0.3.1",
                 "history": "^4.9.0",
                 "less": "^4.1.0",
                 "less2sass": "^1.0.3",
@@ -4132,6 +4133,11 @@
             "dependencies": {
                 "d3-path": "1"
             }
+        },
+        "node_modules/d3-svg-to-png": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/d3-svg-to-png/-/d3-svg-to-png-0.3.1.tgz",
+            "integrity": "sha512-93+xgPo5Jrl/OvZRrxy0eD+K9/PzIZ2fTZv/CJRKdKTIUMav5EtdGRj62wrhQnZlHiEr5aMFK3A1nt2/b5L1mA=="
         },
         "node_modules/d3-time": {
             "version": "1.1.0",
@@ -17417,6 +17423,11 @@
             "requires": {
                 "d3-path": "1"
             }
+        },
+        "d3-svg-to-png": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/d3-svg-to-png/-/d3-svg-to-png-0.3.1.tgz",
+            "integrity": "sha512-93+xgPo5Jrl/OvZRrxy0eD+K9/PzIZ2fTZv/CJRKdKTIUMav5EtdGRj62wrhQnZlHiEr5aMFK3A1nt2/b5L1mA=="
         },
         "d3-time": {
             "version": "1.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.5.0",
+    "version": "7.6.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"
@@ -92,6 +92,7 @@
         "classnames": "^2.2.6",
         "command-line-args": "^5.1.1",
         "cross-spawn": "^7.0.3",
+        "d3-svg-to-png": "^0.3.1",
         "history": "^4.9.0",
         "less": "^4.1.0",
         "less2sass": "^1.0.3",

--- a/packages/ui/src/components/Charts/Bar/index.tsx
+++ b/packages/ui/src/components/Charts/Bar/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { BarDatum, BarSvgProps, ResponsiveBar } from '@nivo/bar';
 import { Typography } from 'antd';
 
+import { numberWithCommas } from '../../../utils/numberUtils';
+
 import styles from './index.module.scss';
 
 type TBarChart = Omit<BarSvgProps<BarDatum>, 'width' | 'height'> & {
@@ -13,6 +15,8 @@ const { Title } = Typography;
 const BarChart = ({
     margin = { bottom: 12, left: 24, right: 24, top: 12 },
     onMouseEnter,
+    enableLabel = true,
+    valueFormat = (value) => numberWithCommas(value ?? 0),
     colorBy = 'indexValue',
     title,
     ...rest
@@ -26,6 +30,7 @@ const BarChart = ({
             )}
             <ResponsiveBar
                 colorBy={colorBy}
+                enableLabel={enableLabel}
                 margin={margin}
                 onMouseEnter={(_: any, e: any) => {
                     if (onMouseEnter) {
@@ -33,10 +38,10 @@ const BarChart = ({
                     }
                     e.target.style.cursor = 'pointer';
                 }}
+                valueFormat={valueFormat}
                 {...rest}
             />
         </div>
     </div>
 );
-
 export default BarChart;

--- a/packages/ui/src/components/Charts/Pie/index.tsx
+++ b/packages/ui/src/components/Charts/Pie/index.tsx
@@ -3,10 +3,14 @@ import { DefaultRawDatum, PieSvgProps, ResponsivePie } from '@nivo/pie';
 import { BasicTooltip } from '@nivo/tooltip';
 import { Typography } from 'antd';
 
+import { numberWithCommas } from '../../../utils/numberUtils';
+
 import styles from './index.module.scss';
 
 export type TPieChart = Omit<PieSvgProps<DefaultRawDatum>, 'width' | 'height'> & {
     title?: string;
+    height?: number;
+    width?: number;
     margin?: {
         top: number;
         bottom: number;
@@ -20,6 +24,7 @@ const { Title } = Typography;
 const PieChart = ({
     margin = { bottom: 16, left: 24, right: 24, top: 16 },
     onMouseEnter,
+    valueFormat: valueFormat = (value) => numberWithCommas(value ?? 0),
     title,
     ...rest
 }: TPieChart): JSX.Element => (
@@ -36,8 +41,13 @@ const PieChart = ({
                     e.target.style.cursor = 'pointer';
                 }}
                 tooltip={(value) => (
-                    <BasicTooltip color={value.datum.color} id={value.datum.id.toString()} value={value.datum.value} />
+                    <BasicTooltip
+                        color={value.datum.color}
+                        id={value.datum.id.toString()}
+                        value={numberWithCommas(value.datum.value)}
+                    />
                 )}
+                valueFormat={valueFormat}
                 {...rest}
             />
             {title && (

--- a/packages/ui/src/graphql/types.ts
+++ b/packages/ui/src/graphql/types.ts
@@ -1,5 +1,3 @@
-import { SortOrder } from 'antd/lib/table/interface';
-
 import { TExtendedMapping } from '../components/filters/types';
 import { ISyntheticSqon } from '../data/sqon/types';
 

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.module.scss
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.module.scss
@@ -1,0 +1,16 @@
+@import "theme.template";
+
+.resizableCard {
+  height: 100%;
+  width: 100%;
+
+  .dropdownMenu {
+    :global(.ant-btn-text) {
+      color: $chart-title-color !important;
+    }
+  }
+}
+
+.modalContentWrapper {
+  position: relative;
+}

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useState } from 'react';
+import { DownloadOutlined } from '@ant-design/icons';
+import { Dropdown, Menu, Modal } from 'antd';
+import d3ToPng from 'd3-svg-to-png';
+import { format } from 'date-fns';
+import { v4 } from 'uuid';
+
+import { GridCardHeader } from '../../../view/v2/GridCard';
+import GridCard, { TGridCard } from '../../../view/v2/GridCard/GridCard';
+
+import styles from './index.module.scss';
+
+type TDictionary = {
+    download?: {
+        fileNameTemplate?: string;
+        fileNameDateFormat?: string;
+        preview?: string;
+        download?: string;
+        data?: string;
+        svg?: string;
+        png?: string;
+    };
+};
+
+type TDownloadSettings = {
+    tsv: boolean;
+    svg: boolean;
+    png: boolean;
+};
+
+type TResizableGridCard = Omit<TGridCard, 'title' | 'resizable'> & {
+    headerTitle: string;
+    dictionary?: TDictionary;
+    modalContent: React.ReactNode;
+    modalSettings?: {
+        width: number;
+        height: number;
+    };
+    tsvSettings?: {
+        headers?: string[];
+        contentMap?: string[];
+        data: any[];
+    };
+    downloadSettings?: TDownloadSettings;
+};
+
+enum DownloadKey {
+    png = 'png',
+    svg = 'svg',
+    tsv = 'tsv',
+}
+
+const EXPORT_SETTINGS = {
+    background: 'white',
+    quality: 0.92,
+    scale: 1,
+};
+const DOWNLOAD_DELAY = 250;
+const DEFAULT_TSV_HEADERS = ['Value', 'Count', 'Frequency'];
+const DEFAULT_TSV_CONTENT_MAP = ['label', 'value', 'frequency'];
+const DEFAULT_FILENAME_TEMPLATE = '%name-chart-%date.%extension';
+const DEFAULT_FILENAME_DATE_FORMAT = 'yyyy-MM-dd';
+
+const chartFileNameFormatter = (
+    fileNameTemplate: string,
+    dateFormat: string,
+    name: string,
+    extension: string,
+): string => {
+    const formattedDate = format(new Date(), dateFormat);
+    return fileNameTemplate
+        .replace('%name', name.toLowerCase().replace(/ /g, ''))
+        .replace('%date', formattedDate)
+        .replace('%extension', extension);
+};
+
+const populateMenuItems = (settings: TDownloadSettings, dictionary?: TDictionary) => {
+    const items = [];
+
+    if (settings.tsv) {
+        items.push({
+            key: DownloadKey.tsv,
+            label: dictionary?.download?.data ?? 'Download data',
+        });
+    }
+
+    if (settings.svg) {
+        items.push({
+            key: DownloadKey.svg,
+            label: dictionary?.download?.svg ?? 'Download SVG',
+        });
+    }
+
+    if (settings.png) {
+        items.push({
+            key: DownloadKey.png,
+            label: dictionary?.download?.png ?? 'Download PNG',
+        });
+    }
+
+    return items;
+};
+
+const ResizableGridCard = ({
+    dictionary,
+    headerTitle,
+    modalContent,
+    modalSettings = { height: 600, width: 800 },
+    downloadSettings = { png: true, svg: true, tsv: true },
+    tsvSettings,
+    ...rest
+}: TResizableGridCard): JSX.Element => {
+    const graphId = `graph-${v4()}`;
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [action, setAction] = useState<DownloadKey>(DownloadKey.tsv);
+    const [hasStartedDownload, setHasStartedDownload] = useState(false);
+
+    const fileNameTemplate = dictionary?.download?.fileNameTemplate ?? DEFAULT_FILENAME_TEMPLATE;
+    const fileNameDateFormat = dictionary?.download?.fileNameDateFormat ?? DEFAULT_FILENAME_DATE_FORMAT;
+    const menuItems = populateMenuItems(downloadSettings, dictionary);
+    const extra = [];
+    if (menuItems.length > 0) {
+        extra.push(
+            <Dropdown.Button
+                className={styles.dropdownMenu}
+                icon={<DownloadOutlined height={11} width={11} />}
+                key="dropdown-menu"
+                overlay={
+                    <Menu
+                        items={menuItems}
+                        key="resizable-card-menu"
+                        onClick={(e) => onMenuClick(e.key as DownloadKey)}
+                    />
+                }
+                size="small"
+                type="text"
+            />,
+        );
+    }
+
+    useEffect(() => {
+        if (!hasStartedDownload) {
+            return;
+        }
+
+        // d3ToPng block react's re-rendering. A timeout is need to force the download state to be set
+        setTimeout(() => {
+            document.querySelectorAll(`#${graphId} svg`).forEach((_, index) => {
+                // d3ToPng only works with string query, not element
+                d3ToPng(
+                    `#${graphId} div:nth-child(${index + 1}) svg`,
+                    chartFileNameFormatter(fileNameTemplate, fileNameDateFormat, headerTitle, action),
+                    { ...EXPORT_SETTINGS, format: action },
+                ).then((_) => {
+                    setHasStartedDownload(false);
+                });
+            });
+        }, DOWNLOAD_DELAY);
+    }, [hasStartedDownload]);
+
+    const onMenuClick = (e: DownloadKey) => {
+        if (e === DownloadKey.tsv) {
+            if (!tsvSettings) {
+                return;
+            }
+
+            tsvSettings.data.forEach((datum) => {
+                let tsvContent = `${tsvSettings.headers?.join('\t') ?? DEFAULT_TSV_HEADERS.join('\t')}\n`;
+                const tsvDataMapping = tsvSettings.contentMap ?? DEFAULT_TSV_CONTENT_MAP;
+
+                datum.forEach((e: any) => {
+                    tsvDataMapping.forEach((key) => {
+                        if (e[key]) {
+                            tsvContent += `${e[key]}\t`;
+                        }
+                    });
+                    tsvContent += `\n`;
+                });
+
+                const hiddenElement = document.createElement('a');
+                hiddenElement.href = 'data:text/tab-separated-values;charset=utf-8,' + encodeURI(tsvContent);
+                hiddenElement.target = '_blank';
+
+                hiddenElement.download = chartFileNameFormatter(fileNameTemplate, fileNameDateFormat, headerTitle, e);
+                hiddenElement.click();
+            });
+
+            return;
+        }
+
+        setAction(e);
+        setIsModalVisible(true);
+    };
+
+    return (
+        <>
+            <Modal
+                confirmLoading={hasStartedDownload}
+                okText={dictionary?.download?.download ?? 'Download'}
+                onCancel={() => setIsModalVisible(false)}
+                onOk={() => {
+                    setHasStartedDownload(true);
+                }}
+                title={`${dictionary?.download?.preview ?? 'Download preview - '}${headerTitle}.${action}`}
+                visible={isModalVisible}
+                width={modalSettings.width}
+            >
+                <div className={styles.modalContentWrapper} id={graphId} style={{ height: modalSettings.height }}>
+                    {modalContent}
+                </div>
+            </Modal>
+            <GridCard
+                contentClassName={styles.resizableCard}
+                loadingType="spinner"
+                resizable
+                title={<GridCardHeader extra={extra} id={headerTitle} title={headerTitle} withHandle />}
+                wrapperClassName={styles.resizableCard}
+                {...rest}
+            />
+        </>
+    );
+};
+
+export default ResizableGridCard;

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableItemSelector/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SettingOutlined } from '@ant-design/icons';
-import { Button, Checkbox, List, Popover, Space, Tooltip } from 'antd';
+import { Button, Checkbox, Popover, Space, Tooltip } from 'antd';
 
 import styles from './index.module.scss';
 

--- a/packages/ui/src/layout/ResizableGridLayout/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/index.tsx
@@ -261,7 +261,7 @@ const ResizableGridLayout = ({
                             onConfigUpdate(serializeLayoutsToConfig(allLayouts, configs));
                         }}
                         rowHeight={98}
-                        width={size.width !== null ? size.width : 1280}
+                        width={size.width && size.width !== null ? size.width : 1280}
                         {...props}
                     >
                         {configs.map((layout) => {

--- a/packages/ui/src/layout/ResizableGridLayout/utils.ts
+++ b/packages/ui/src/layout/ResizableGridLayout/utils.ts
@@ -1,0 +1,12 @@
+import { ArrangerValues } from '../../data/arranger/formatting';
+
+export const aggregationToChartData = (buckets: any[] = [], total?: number) =>
+    buckets.map(({ doc_count, key }) => {
+        const dataKey = key === ArrangerValues.missing ? 'No Data' : key;
+        return {
+            frequency: total ? (doc_count * 100) / total : '',
+            id: dataKey,
+            label: dataKey,
+            value: doc_count,
+        };
+    });

--- a/packages/ui/src/utils/numberUtils.ts
+++ b/packages/ui/src/utils/numberUtils.ts
@@ -43,6 +43,8 @@ export const numberFormat = (num: number, digits = 0) => {
     }
 };
 
+export const numberWithCommas = (number: number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
 export const toExponentialNotation = (numberCandidate?: number, fractionDigits = 2): string =>
     numberCandidate ? numberCandidate.toExponential(fractionDigits) : '';
 

--- a/packages/ui/src/view/v2/GridCard/GridCard.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCard.tsx
@@ -7,7 +7,7 @@ import ConditionalWrapper from '../../../components/utils/ConditionalWrapper';
 
 import styles from './Gridcard.module.scss';
 
-type OwnProps = CardProps & {
+export type TGridCard = CardProps & {
     footer?: React.ReactNode;
     content: React.ReactNode;
     theme?: 'shade' | 'light';
@@ -30,7 +30,7 @@ const GridCard = ({
     theme = 'light',
     wrapperClassName = '',
     ...rest
-}: Omit<OwnProps, 'actions'>) => (
+}: Omit<TGridCard, 'actions'>) => (
     <div className={cx(wrapperClassName, styles.fuiCardWrapper)}>
         <Card
             {...rest}

--- a/storybook/stories/Layout/ResizableGridLayout.stories.tsx
+++ b/storybook/stories/Layout/ResizableGridLayout.stories.tsx
@@ -1,25 +1,102 @@
-import ResizableGridLayout, {TSerializedResizableGridLayoutConfig, IResizableGridLayoutConfig} from '@ferlab/ui/layout/ResizableGridLayout';
-import GridCard, { GridCardHeader } from '@ferlab/ui/view/v2/GridCard';
-import { Meta } from "@storybook/react/types-6-0";
 import React from "react";
+import ResizableGridLayout, {TSerializedResizableGridLayoutConfig, IResizableGridLayoutConfig} from '@ferlab/ui/layout/ResizableGridLayout';
+import { Meta } from "@storybook/react/types-6-0";
+import ResizableGridCard from '@ferlab/ui/layout/ResizableGridLayout/ResizableGridCard';
+import BarChart from "@ferlab/ui/components/Charts/Bar";
+import PieChart from "@ferlab/ui/components/Charts/Pie";
+import { aggregationToChartData } from '@ferlab/ui/layout/ResizableGridLayout/utils';
 
-import styles from './ResizableGridLayout.module.scss';
 
-const GridCardItem = ({ id }: { id: string }) => (
-    <GridCard 
-        wrapperClassName={styles.wrapper}
-        theme="shade" 
-        resizable
-        title={
-                <GridCardHeader
-                id={id}
-                title={`GridCard Header ${id}`}
-                withHandle
-                />
-        }
-        content={<div style={{height: "100%", width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center'}}>{id}</div>} 
-    />
-);
+const GridCardItem = ({ type }: { type: string }) => {
+    var buckets = [];
+    var total =  Math.floor(Math.random() * 10) + 1;
+    for (let i = 0; i < total; i++) {
+        buckets.push({
+            key: `random id_${i}`,
+            doc_count: Math.floor(Math.random() * 100)+ 1
+        })
+    }
+
+    const data = aggregationToChartData(buckets, total);
+
+    return (
+        <ResizableGridCard
+            theme="shade"
+            loading={false}
+            loadingType="spinner"
+            headerTitle={"header title"}
+            tsvSettings={{
+                data: [data],
+            }}
+            modalContent={
+                <>
+                    {type == 'bar'? (
+                        <BarChart
+                        data={data}
+                        axisLeft={{
+                            legend: 'Data Types',
+                            legendPosition: 'middle',
+                            legendOffset: -128,
+                        }}
+                        tooltipLabel={(node: any) => node.data.id}
+                        axisBottom={{
+                            legend: '# of participants',
+                            legendPosition: 'middle',
+                            legendOffset: 35,
+                        }}
+                        margin={{
+                            bottom: 45,
+                            left: 140,
+                            right: 12,
+                            top: 12,
+                        }}
+                        layout="horizontal"
+                        />
+                    ): (
+                        <PieChart
+                            data={data}
+                        />
+                    )}
+                </>
+            }
+            content={
+                <div style={{height: '100%', 'width': '100%'}}>
+                        <>
+                            {type == 'bar'? (
+                                <BarChart
+                                data={data}
+                                axisLeft={{
+                                    legend: 'Data Types',
+                                    legendPosition: 'middle',
+                                    legendOffset: -128,
+                                }}
+                                tooltipLabel={(node: any) => node.data.id}
+                                axisBottom={{
+                                    legend: '# of participants',
+                                    legendPosition: 'middle',
+                                    legendOffset: 35,
+                                }}
+                                margin={{
+                                    bottom: 45,
+                                    left: 140,
+                                    right: 12,
+                                    top: 12,
+                                }}
+                                layout="horizontal"
+                                />
+                            ): (
+                                <PieChart
+                                    data={data}
+                                />
+                            )}
+                        </>
+                </div>
+            }
+        />
+    );
+
+}
+
 const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     {
         base: {
@@ -30,7 +107,7 @@ const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
             x: 0,
             y: 0,
         },
-        component: <GridCardItem id="card_1" />,
+        component: <GridCardItem type="bar" />,
         id: 'card_1',
         title: 'Card 1',
     },
@@ -43,7 +120,7 @@ const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
             x: 6,
             y: 0,
         },
-        component: <GridCardItem id="card_2" />,
+        component: <GridCardItem type="pie" />,
         id: 'card_2',
         title: 'Card 2',
     },
@@ -56,7 +133,7 @@ const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
             x: 0,
             y: 3,
         },
-        component: <GridCardItem id="card_3" />,
+        component: <GridCardItem type="bar" />,
         id: 'card_3',
         title: 'Card 3',
     },
@@ -69,7 +146,7 @@ const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
             x: 7,
             y: 3,
         },
-        component: <GridCardItem id="card_4" />,
+        component: <GridCardItem type="pie" />,
         id: 'card_4',
         title: 'Card 4',
     },


### PR DESCRIPTION
#  FEATURE 

- closes #[698](https://d3b.atlassian.net/browse/SKFP-698)

## Description

```
Implement the download by png, svg through a preview modal that will include the chart values and legend. In the modal, the user will have a preview of the chart and will be able to confirm and proceed to the download for the specific file format (PNG, SVG), or cancel and close the modal. The download data will be done directly from the chart’s dropdown and will not open a modal. (TSV) . 

- Modal title: “Download preview – Chart Title"
  Download PNG/SVG values and legend examples:
  Demographics, Participant by Data Type, Participant by Data Category, Age at Diagnosis, Studies.
    Value: Male , Count: 6769, Frequency: (50.89%) 
    e.g.,red Male 6769 (50.89%)
- For the 2 sunbursts, for now we can display simply display the image of the sunburst as it is in the Summary View including the description on the right hand side of the chart widget. 
- The download data (tsv format) would capture the Value (Sex:Male) , Count (4235) , and Frequency (% of the value over the total values) for most of the graphs in the Data Exploration.
- For the 2 sunbursts, we shouldn't be able to download tsv. Only PNG and SVG
- Download PNG/SVG File naming: kidsfirst-chart title-chart-year-month-day
  Download data File naming: kidsfirst-chart title-data-year-month-day
- The chart titles that have multiple words, it can all be set in lowercase, without any separation: ex.-participantbydatatype- 
- 
```

Acceptance Criterias

## Validation de Qualité


- [ ] Validation du design avec design figma (dev)
- [x] QA - Validation des critère de succès (via screenshot)
- [ ] Design/UI - Validation du respect du design/theme

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/eef490cc-c1a7-4984-80c7-c892a64215f8)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/c3f491d5-0513-46fa-9427-30f1e813a960)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1c894b76-403d-44c7-b500-103c02782b9b)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/73027629-aca3-4aa4-92e4-a37a447cef2e)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/d00d40ae-c4f7-40ea-8930-bb999331333f)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/222a6e5c-2322-452b-bef7-d881b5bb2adb)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/2df4e47c-2a42-495a-98e1-cba3d9deddb1)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/941f309b-dfea-44cf-9988-1f286e96fd4f)


https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/519b1b64-86dc-4d1c-9bae-47b17eb96d85
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/86b00dee-573c-46bd-9812-7b0325cb7d6e
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/b24cc69c-b135-4b25-997b-570fa44b2d6d


## Mention
@luclemo @kstonge

