### PR TITLE
feat(number): FLUI-65 manage locale in number

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.6.0",
+    "version": "7.7.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/utils/localeUtils.test.ts
+++ b/packages/ui/src/utils/localeUtils.test.ts
@@ -1,0 +1,44 @@
+import { setLocale } from './localeUtils';
+
+export const localStorageMock = (function () {
+    let store: any = {};
+    return {
+        clear: function () {
+            store = {};
+        },
+        getItem: (key: string) => store[key],
+        removeItem: function (key: string) {
+            delete store[key];
+        },
+        setItem: function (key: string, value: string) {
+            store[key] = value.toString();
+        },
+    };
+})();
+
+describe(`${setLocale.name}()`, () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+    });
+    it('should setItem with "fr" if locale is "fr"', () => {
+        setLocale('fr');
+        expect(localStorage.getItem('locale')).toStrictEqual('fr');
+    });
+    it('should setItem with "en" if locale is "en"', () => {
+        setLocale('en');
+        expect(localStorage.getItem('locale')).toStrictEqual('en');
+    });
+    it('should setItem with "en" if locale is undefined', () => {
+        setLocale(undefined as never);
+        expect(localStorage.getItem('locale')).toStrictEqual('en');
+    });
+    it('should setItem with "en" if locale is null', () => {
+        setLocale(null as never);
+        expect(localStorage.getItem('locale')).toStrictEqual('en');
+    });
+    it('should setItem with "en" if locale is an empty string', () => {
+        setLocale('');
+        expect(localStorage.getItem('locale')).toStrictEqual('en');
+    });
+});

--- a/packages/ui/src/utils/localeUtils.ts
+++ b/packages/ui/src/utils/localeUtils.ts
@@ -1,0 +1,3 @@
+export const setLocale = (locale: string): void => {
+    localStorage.setItem('locale', locale || 'en');
+};

--- a/packages/ui/src/utils/numberUtils.test.ts
+++ b/packages/ui/src/utils/numberUtils.test.ts
@@ -33,10 +33,34 @@ describe(`${numberFormat.name}()`, () => {
         expect(numberFormat(0)).toBe(0);
     });
 
-    it('should return the localized string if num is in BLACK_LIST_LENGTH', () => {
+    it('should return the english localized string if num is in BLACK_LIST_LENGTH and locale is en', () => {
+        localStorage.setItem('locale', 'en');
         expect(numberFormat(1)).toBe('1');
         expect(numberFormat(10)).toBe('10');
         expect(numberFormat(100)).toBe('100');
+        expect(numberFormat(1000)).toBe('1,000');
+    });
+
+    it('should return the french localized string if num is in BLACK_LIST_LENGTH and locale is fr', () => {
+        localStorage.setItem('locale', 'fr');
+        expect(numberFormat(1)).toBe('1');
+        expect(numberFormat(10)).toBe('10');
+        expect(numberFormat(100)).toBe('100');
+        expect(numberFormat(1000)).toEqual('1\xa0000');
+    });
+
+    it('should return the default localized string if num is in BLACK_LIST_LENGTH and locale is not defined', () => {
+        localStorage.setItem('locale', undefined as never);
+        expect(numberFormat(1000)).toBe('1,000');
+    });
+
+    it('should return the default localized string if num is in BLACK_LIST_LENGTH and locale is null', () => {
+        localStorage.setItem('locale', null as never);
+        expect(numberFormat(1000)).toBe('1,000');
+    });
+
+    it('should return the default localized string if num is in BLACK_LIST_LENGTH and locale is an empty string', () => {
+        localStorage.setItem('locale', '');
         expect(numberFormat(1000)).toBe('1,000');
     });
 

--- a/packages/ui/src/utils/numberUtils.ts
+++ b/packages/ui/src/utils/numberUtils.ts
@@ -23,11 +23,13 @@ export const getDefaultDigits = (num: number) => {
 export const numberFormat = (num: number, digits = 0) => {
     if (!num) return 0;
 
+    const locale = localStorage.getItem('locale') === 'fr' ? 'fr-CA' : 'en-US';
+
     let index: number;
     digits = digits ? digits : getDefaultDigits(num);
 
     if (BLACK_LIST_LENGTH.includes(num.toString().length)) {
-        return num.toLocaleString();
+        return num.toLocaleString(locale);
     } else {
         VALUE_SYMBOLE_LIST.forEach((si: any, i) => {
             if (num >= si.value) {


### PR DESCRIPTION
# FEAT : Number format

## Description

[FLUI-65](https://ferlab-crsj.atlassian.net/browse/FLUI-65)
Actually the method `numberFormat` takes by default the local of the browser when it’s not specified. We would like to choose and specify the locale to display the right format.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### en locale in localStorage
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/693ba91e-235c-4d1c-bc5b-056a69c7f546)

### fr locale in localeStorage
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/5a356027-99c3-4e33-995e-c1bf8f758fac)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
