### PR TITLE
feat: move RangeFilter noDataInputOption into config instead of props

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.3 2023-06-08
+- feat: CLIN-1991 move noDataInputOption for rangeFilter into config props
+ 
 ### 7.9.0 2023-06-05
 - feat: FLUI-67 update antd@4.24.10
  

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.6.0",
+    "version": "7.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.6.0",
+            "version": "7.9.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.2",
+    "version": "7.9.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/RangeFilter.tsx
+++ b/packages/ui/src/components/filters/RangeFilter.tsx
@@ -33,7 +33,6 @@ export type RangeFilterProps = {
     onChange: onChangeType<IFilterRange>;
     selectedFilters?: IFilter[];
     dictionary?: IDictionary | Record<string, never>;
-    noDataInputOption?: boolean;
 };
 
 const DEFAULT_STEP = 1;
@@ -147,13 +146,13 @@ const RangeFilter = ({
     dictionary,
     filterGroup,
     filters,
-    noDataInputOption = true,
     onChange,
     selectedFilters,
 }: RangeFilterProps): React.ReactElement | null => {
     const { config: range } = filterGroup;
     const currentFilter: IFilter<IFilterRange> = filters[0];
     const rangeTypes = filterGroup.config?.rangeTypes;
+    const noDataInputOption = filterGroup.config?.noDataInputOption ?? true;
     const defaultOperators = getDefaultOperatorList(
         dictionary,
         filterGroup.config?.defaultOperator || RangeOperators['<'],

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -48,6 +48,7 @@ export interface IFilterRangeConfig {
     operators?: IRangeOperatorConfig[];
     rangeTypes?: IFilterRangeTypes[];
     defaultOperator?: RangeOperators;
+    noDataInputOption?: boolean;
 }
 
 export interface IFilterTextInputConfig {

--- a/storybook/stories/Components/Filters/RangeFilter.stories.tsx
+++ b/storybook/stories/Components/Filters/RangeFilter.stories.tsx
@@ -142,6 +142,23 @@ WithNoDataCheckbox.args = {
         config: {
             min: 1,
             max: 2,
+            noDataInputOption: true
+        },
+        title: 'title_filter_group',
+    },
+    filters: rangeFilters,
+    onChange: () => undefined,
+};
+export const WithoutNoDataCheckbox = RangeFilterStory.bind({});
+WithoutNoDataCheckbox.args = {
+    title: 'RangeFilter Without No Data Checkbox',
+    filterGroup: {
+        type: VisualType.Range,
+        field: 'this.field',
+        config: {
+            min: 1,
+            max: 2,
+            noDataInputOption: false
         },
         title: 'title_filter_group',
     },


### PR DESCRIPTION
# FEAT : NODATAINPUTOPTION now in config props

- closes #CLIN-1991

## Description
Move RangeFilter noDataInputOption into config instead of props

[JIRA LINK]

Acceptance Criterias
Able to show/hide the noData checkout with the config props

## Validation

- [x] Storybook add or modified
- [x] version Update in package.json and Release.md
- [ ] Code Approved
- [x] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/10870599/1d1045c3-6bbe-42e1-9b1e-9d1db1ef54b3)


## QA

Steps to validate
Url (storybook, ...)
Storybook : path=/story/ferlab-components-filters-rangefilter--with-no-data-checkbox
...

## Mention

@kstonge @luclemo
