### PR TITLE
fix: FLUI-72 fixed breaking css change from antd update

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.8 2023-06-16
+- fix: FLUI-72 fixed breaking css change from antd update 
+
 ### 7.9.7 2023-06-15
 - fix: FLUI-67 72 updates antd preventUrlHash default false AnchorMenu
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.7",
+    "version": "7.9.8",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/themes/default/_antd.scss
+++ b/packages/ui/themes/default/_antd.scss
@@ -1,4 +1,5 @@
 .ant-space-compact-block {
   display: inline-flex;
-  width: inherit;
+  width: unset;
+  max-width: 100%
 }


### PR DESCRIPTION
# FIX: [Facettes] Les boutons Clear/Apply ont changés de place

- closes #FLUI-72

## Description

[JIRA LINK]

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
