### PR TITLE
fix(anchor): FLUI-74 remove prevent url hash

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.4",
+    "version": "7.9.8-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.9.4",
+            "version": "7.9.8-rc1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.7",
+    "version": "7.9.8-rc1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/AnchorMenu/index.tsx
+++ b/packages/ui/src/components/AnchorMenu/index.tsx
@@ -14,7 +14,6 @@ export interface IAnchorLink {
 export interface IAnchorMenuProps extends AnchorProps {
     className?: string;
     scrollContainerId: string;
-    preventUrlHash?: boolean;
     links: IAnchorLink[];
 }
 
@@ -28,16 +27,11 @@ const AnchorMenu = ({
     offsetTop,
     onChange,
     prefixCls,
-    preventUrlHash = true,
     scrollContainerId,
     showInkInFixed,
     targetOffset,
 }: IAnchorMenuProps) => {
     const scrollContainer = document.getElementById(scrollContainerId);
-
-    const handlePreventUrlHash = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-    };
 
     const filteredLinks = links.filter((link) => !link.hidden);
 
@@ -55,7 +49,6 @@ const AnchorMenu = ({
             getCurrentAnchor={getCurrentAnchor || _getCurrentAnchor}
             offsetTop={offsetTop}
             onChange={onChange}
-            onClick={preventUrlHash ? handlePreventUrlHash : undefined}
             prefixCls={prefixCls}
             showInkInFixed={showInkInFixed}
             targetOffset={targetOffset}

--- a/packages/ui/src/pages/EntityPage/EntityPage.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityPage.tsx
@@ -17,15 +17,7 @@ export interface IEntityPage {
     preventUrlHash?: boolean;
 }
 
-const EntityPage: React.FC<IEntityPage> = ({
-    children,
-    data,
-    emptyText,
-    links,
-    loading,
-    pageId = '',
-    preventUrlHash = false,
-}) => {
+const EntityPage: React.FC<IEntityPage> = ({ children, data, emptyText, links, loading, pageId = '' }) => {
     const [scrollContainerId, setScrollContainerId] = useState<string>(pageId);
     const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
 
@@ -43,12 +35,7 @@ const EntityPage: React.FC<IEntityPage> = ({
     return (
         <div className={styles.entityPageContainer}>
             <ScrollContent className={styles.scrollContent}>{children}</ScrollContent>
-            <AnchorMenu
-                className={styles.anchorMenu}
-                links={links}
-                preventUrlHash={preventUrlHash}
-                scrollContainerId={scrollContainerId}
-            />
+            <AnchorMenu className={styles.anchorMenu} links={links} scrollContainerId={scrollContainerId} />
         </div>
     );
 };


### PR DESCRIPTION
# FIX : Anchor menu is not working

- closes [FLUI-74](https://ferlab-crsj.atlassian.net/browse/FLUI-74)
- 
## Description

Just to test because anchor menu is not working only with an installed version not with a link.
I have removed the logic aroung prevent url hash on the anchor menu onClick.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/c3d74ca9-56ee-4374-8d7a-f7ba43bbdb67)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/392b8d5e-066d-47de-9f83-ba158871cb75)

