### PR TITLE
feat(filter): FLUI-76 add no data option to range filter config

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.10 2023-06-27
+- feat: FLUI-76 add no data option for range filter
+
 ### 7.9.9 2023-06-19
 - fix: FLUI-74 remove preventUrlHash on anchor menu
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.9",
+    "version": "7.9.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.9.9",
+            "version": "7.9.10",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.9",
+    "version": "7.9.10",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -68,6 +68,7 @@ export interface IFilterGroup<T extends TFilterGroupConfig = any> {
     title: ReactNode;
     type: VisualType;
     headerTooltip?: string;
+    noDataInputOption?: boolean;
 }
 
 export interface IFilterCount {

--- a/packages/ui/src/data/filters/utils.ts
+++ b/packages/ui/src/data/filters/utils.ts
@@ -9,10 +9,12 @@ import { createSQONFromFilters, isReference } from '../sqon/utils';
 
 import { isRangeAgg } from './Range';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getQueryParams = (search: string | null = null) =>
     search ? qs.parse(search) : qs.parse(window.location.search);
 
 /** @deprecated */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const updateFilters = (history: any, filterGroup: IFilterGroup, selected: IFilter[], index?: string): void =>
     updateQueryFilters(history, filterGroup.field, createSQONFromFilters(filterGroup, selected, index));
 
@@ -27,6 +29,7 @@ export const getFilterType = (fieldType: string): VisualType => {
 
 /** @deprecated */
 export const updateQueryFilters = (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     history: any,
     field: string,
     filters: TSyntheticSqonContent,
@@ -34,7 +37,7 @@ export const updateQueryFilters = (
 ): void => {
     const currentFilter = getFiltersQuery();
 
-    let newFilters: ISyntheticSqon | object = { content: filters, op: operator };
+    let newFilters: ISyntheticSqon | Record<string, unknown> = { content: filters, op: operator };
 
     if (!isEmpty(currentFilter)) {
         const results = getFilterWithNoSelection(currentFilter, field);
@@ -45,7 +48,7 @@ export const updateQueryFilters = (
         if (isEmpty(filterWithoutSelection.content) && isEmpty(filters)) {
             newFilters = {};
         } else {
-            if (fieldIndex >= 0) {
+            if (typeof fieldIndex === 'number' && fieldIndex >= 0) {
                 filterWithoutSelection.content.splice(fieldIndex as number, 0, ...filters);
             } else {
                 filterWithoutSelection.content = [...filterWithoutSelection.content, ...filters];
@@ -84,6 +87,7 @@ const getFilterWithNoSelection = (filters: ISyntheticSqon, field: string) => {
     ];
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const updateQueryParam = (history: any, key: string, value: any): void => {
     const query = getQueryParams();
 
@@ -119,16 +123,24 @@ interface IValues<T> {
 
 export const readQueryParam = <T = ''>(key: string, options: IValues<T>, search: any = null): any => {
     const query = getQueryParams(search);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return get<any, any, T>(query, key, options.defaultValue)!;
 };
 
+interface IUsefilters {
+    filters: {
+        content: never[];
+        op: BooleanOperators;
+    };
+}
 /** @deprecated */
-export const useFilters = (filterKey = 'filters') => {
+export const useFilters = (filterKey = 'filters'): IUsefilters => {
     let filters = { filters: { content: [], op: BooleanOperators.and } };
     const searchParams = new URLSearchParams(window.location.search);
 
     if (searchParams.has(filterKey) && searchParams.get(filterKey)) {
         try {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const filterData = JSON.parse(searchParams.get(filterKey)!);
             if (typeof filterData == 'object') {
                 filters = { filters: filterData };
@@ -149,6 +161,7 @@ export const getQueryBuilderCache = (type: string): any => {
 
     try {
         // To support old query builder cache format
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const qbCache = JSON.parse(items!);
         const state = qbCache.state || [];
         return {
@@ -173,6 +186,7 @@ export const getQueryBuilderCache = (type: string): any => {
 };
 
 /** @deprecated */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const setQueryBuilderCache = (type: string, items: any): void => {
     localStorage.setItem(`query-builder-cache-${type}`, JSON.stringify(items));
 };

--- a/packages/ui/src/data/filters/utils.ts
+++ b/packages/ui/src/data/filters/utils.ts
@@ -194,20 +194,31 @@ export const createQueryParams = (queryParams: IQueryParams): string => {
     return `?${qs.stringify(query)}`;
 };
 
-export const getFilterGroup = (
-    extendedMapping: TExtendedMapping | undefined,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    aggregation: any,
-    rangeTypes: string[],
-    filterFooter: boolean,
-    headerTooltip?: boolean,
-    dictionary?: IFacetDictionary,
-): IFilterGroup => {
+interface IGetFilterGroup {
+    extendedMapping: TExtendedMapping | undefined;
+    aggregation: any;
+    rangeTypes: string[];
+    filterFooter: boolean;
+    headerTooltip?: boolean;
+    dictionary?: IFacetDictionary;
+    noDataInputOption?: boolean;
+}
+
+export const getFilterGroup = ({
+    aggregation,
+    dictionary,
+    extendedMapping,
+    filterFooter,
+    headerTooltip,
+    noDataInputOption = true,
+    rangeTypes,
+}: IGetFilterGroup): IFilterGroup => {
     if (isRangeAgg(aggregation)) {
         return {
             config: {
                 max: aggregation.stats.max,
                 min: aggregation.stats.min,
+                noDataInputOption: noDataInputOption,
                 rangeTypes: rangeTypes.map((r) => ({
                     key: r,
                     name: r,


### PR DESCRIPTION
# FEAT : Add noDataInputOption to range filter

- closes [FLUI-76](https://ferlab-crsj.atlassian.net/browse/FLUI-76)

## Description

The option to display or hide the no data checkbox in a range filter exists but it's not taking into account so I have added it to getFilterGroup to hide the checkbox.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
