### PR TITLE
feat(range filter): FLUI-77 add interval decimal

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.11 2023-06-29
+- feat: FLUI-77 add interval decimal in RangeFilter
+
 ### 7.9.10 2023-06-27
 - feat: FLUI-76 add no data option for range filter
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.10",
+    "version": "7.9.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.9.10",
+            "version": "7.9.11",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.11-rc4",
+    "version": "7.9.11",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/RangeFilter.tsx
+++ b/packages/ui/src/components/filters/RangeFilter.tsx
@@ -158,6 +158,10 @@ const RangeFilter = ({
         filterGroup.config?.defaultOperator || RangeOperators['<'],
     );
     const operatorsList = range?.operators?.length ? range?.operators : defaultOperators;
+    const intervalDecimal =
+        filterGroup.config?.intervalDecimal || filterGroup.config?.intervalDecimal === 0
+            ? filterGroup.config.intervalDecimal
+            : 3;
 
     const {
         selectedMax = undefined,
@@ -295,8 +299,8 @@ const RangeFilter = ({
                 </StackLayout>
                 {hasConfigStep(filterGroup) && (
                     <Text className={styles.fuiRfRangeInterval} type="secondary">
-                        {get(dictionary, 'range.actualInterval', 'Actual interval')} : {range.min?.toFixed(3)} -{' '}
-                        {range.max?.toFixed(3)}
+                        {get(dictionary, 'range.actualInterval', 'Actual interval')} :{' '}
+                        {range.min?.toFixed(intervalDecimal)} - {range.max?.toFixed(intervalDecimal)}
                     </Text>
                 )}
                 {!!range?.rangeTypes?.length && (

--- a/packages/ui/src/components/filters/RangeFilter.tsx
+++ b/packages/ui/src/components/filters/RangeFilter.tsx
@@ -12,6 +12,7 @@ import GreaterThanOperatorIcon from './icons/GreaterThanOperatorIcon';
 import GreaterThanOrEqualOperatorIcon from './icons/GreaterThanOrEqualOperatorIcon';
 import LessThanOperatorIcon from './icons/LessThanOperatorIcon';
 import LessThanOrEqualOperatorIcon from './icons/LessThanOrEqualOperatorIcon';
+import { INTERVAL_DECIMAL } from './constants';
 import {
     IDictionary,
     IFilter,
@@ -161,7 +162,7 @@ const RangeFilter = ({
     const intervalDecimal =
         filterGroup.config?.intervalDecimal || filterGroup.config?.intervalDecimal === 0
             ? filterGroup.config.intervalDecimal
-            : 3;
+            : INTERVAL_DECIMAL;
 
     const {
         selectedMax = undefined,

--- a/packages/ui/src/components/filters/constants.ts
+++ b/packages/ui/src/components/filters/constants.ts
@@ -1,0 +1,1 @@
+export const INTERVAL_DECIMAL = 3;

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -49,6 +49,7 @@ export interface IFilterRangeConfig {
     rangeTypes?: IFilterRangeTypes[];
     defaultOperator?: RangeOperators;
     noDataInputOption?: boolean;
+    intervalDecimal?: number;
 }
 
 export interface IFilterTextInputConfig {

--- a/packages/ui/src/data/filters/utils.ts
+++ b/packages/ui/src/data/filters/utils.ts
@@ -216,6 +216,7 @@ interface IGetFilterGroup {
     headerTooltip?: boolean;
     dictionary?: IFacetDictionary;
     noDataInputOption?: boolean;
+    intervalDecimal?: number;
 }
 
 export const getFilterGroup = ({
@@ -224,12 +225,14 @@ export const getFilterGroup = ({
     extendedMapping,
     filterFooter,
     headerTooltip,
+    intervalDecimal,
     noDataInputOption = true,
     rangeTypes,
 }: IGetFilterGroup): IFilterGroup => {
     if (isRangeAgg(aggregation)) {
         return {
             config: {
+                intervalDecimal,
                 max: aggregation.stats.max,
                 min: aggregation.stats.min,
                 noDataInputOption: noDataInputOption,


### PR DESCRIPTION
# FEAT : Add interval decimal to range filter

- closes [FLUI-77](https://ferlab-crsj.atlassian.net/browse/FLUI-77)

## Description

Add a props to be able to custom the number of decimal in the actual interval display in a range filter.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/3d4bcd54-8db2-425d-8f66-ed43546bdc61)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/b8bba4fe-8030-4423-a280-5f2009ec511d)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
