### PR TITLE
fix(resizablegrid): SKFP-698 fix file name and typo

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.12-rc3",
+    "version": "7.9.12",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
# FIX

- closes #[698](https://d3b.atlassian.net/browse/SKFP-698)

## Description

1. L’item « Download data » devrait être Sentence case

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/5533290f-31a7-4819-bfc0-c60b1e3cf6a9)


2. Le nom des fichier générés pour le TSV devrait dontenir data au lieu de chart
3. Le nom des images contiennent deux fois l’extension

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/921adb64-1964-40a9-8258-b2071534ef0d)


