### PR TITLE
fix(anchor menu): FLUI-74 / SJIP- 511 fix scroll page

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,5 +1,8 @@
+### 7.9.13 2023-06-29
+- fix: FLUI-74/SJIP-511 anchor menu higlight follow scroll
+
 ### 7.9.12 2023-06-29
-- feat: FLUI-74/SJIP-511 anchor menu higlight follow scroll
+- fix: SKFP-698 resizable grid fix file name and typo
 
 ### 7.9.11 2023-06-29
 - feat: FLUI-77 add interval decimal in RangeFilter

--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.12 2023-06-29
+- feat: FLUI-74/SJIP-511 anchor menu higlight follow scroll
+
 ### 7.9.11 2023-06-29
 - feat: FLUI-77 add interval decimal in RangeFilter
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.12",
+    "version": "7.9.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.9.12",
+            "version": "7.9.13",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.11",
+    "version": "7.9.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.9.11",
+            "version": "7.9.12",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -71,7 +71,7 @@
                 "webpack-cli": "^3.3.12"
             },
             "peerDependencies": {
-                "antd": "^4.24.10",
+                "antd": "^4.24.11",
                 "date-fns": "^2.29.3",
                 "react": "^17.0.2 || ^18.0.0",
                 "react-dom": "^17.0.2 || ^18.0.0"
@@ -2586,9 +2586,9 @@
             }
         },
         "node_modules/antd": {
-            "version": "4.24.10",
-            "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.10.tgz",
-            "integrity": "sha512-GihdwTGFW0dUaWjcvSIfejFcT63HjEp2EbYd+ojEXayldhey230KrHDJ+C53rkrkzLvymrPBfSxlLxJzyFIZsg==",
+            "version": "4.24.11",
+            "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.11.tgz",
+            "integrity": "sha512-IybWxM0Nie1nJpiLxJCkp4CPwYF8ZvQLmGcG+mx4nZJuTNGcbPYHnZ4o5rCH0GdrAO4WBRNFu2Hz+tPsqsIKEw==",
             "dependencies": {
                 "@ant-design/colors": "^6.0.0",
                 "@ant-design/icons": "^4.7.0",
@@ -2603,9 +2603,9 @@
                 "rc-checkbox": "~3.0.0",
                 "rc-collapse": "~3.4.2",
                 "rc-dialog": "~9.0.2",
-                "rc-drawer": "~6.1.0",
+                "rc-drawer": "~6.3.0",
                 "rc-dropdown": "~4.0.0",
-                "rc-field-form": "~1.27.0",
+                "rc-field-form": "~1.30.0",
                 "rc-image": "~5.13.0",
                 "rc-input": "~0.1.4",
                 "rc-input-number": "~7.3.9",
@@ -10105,12 +10105,12 @@
             }
         },
         "node_modules/rc-drawer": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.1.6.tgz",
-            "integrity": "sha512-EBRFM9o3lPU5kYh8sFoXYA9KxpdT765HDqj/AbZWicXkhwEYUH7MjUH0ctenPCiHBxXQUgIUvK14+6rPuURd6w==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.3.0.tgz",
+            "integrity": "sha512-uBZVb3xTAR+dBV53d/bUhTctCw3pwcwJoM7g5aX+7vgwt2zzVzoJ6aqFjYJpBlZ9zp0dVYN8fV+hykFE7c4lig==",
             "dependencies": {
                 "@babel/runtime": "^7.10.1",
-                "@rc-component/portal": "^1.0.0-6",
+                "@rc-component/portal": "^1.1.1",
                 "classnames": "^2.2.6",
                 "rc-motion": "^2.6.1",
                 "rc-util": "^5.21.2"
@@ -10136,9 +10136,9 @@
             }
         },
         "node_modules/rc-field-form": {
-            "version": "1.27.4",
-            "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
-            "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.30.0.tgz",
+            "integrity": "sha512-hCBa3/+m9SSuEPILSsxB/wd3ZFEmNTQfIhThhMaMp05fLwDDw+2K26lEZf5NuChQlx90VVNUOYmTslH6Ks4tpA==",
             "dependencies": {
                 "@babel/runtime": "^7.18.0",
                 "async-validator": "^4.1.0",
@@ -16117,9 +16117,9 @@
             }
         },
         "antd": {
-            "version": "4.24.10",
-            "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.10.tgz",
-            "integrity": "sha512-GihdwTGFW0dUaWjcvSIfejFcT63HjEp2EbYd+ojEXayldhey230KrHDJ+C53rkrkzLvymrPBfSxlLxJzyFIZsg==",
+            "version": "4.24.11",
+            "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.11.tgz",
+            "integrity": "sha512-IybWxM0Nie1nJpiLxJCkp4CPwYF8ZvQLmGcG+mx4nZJuTNGcbPYHnZ4o5rCH0GdrAO4WBRNFu2Hz+tPsqsIKEw==",
             "requires": {
                 "@ant-design/colors": "^6.0.0",
                 "@ant-design/icons": "^4.7.0",
@@ -16134,9 +16134,9 @@
                 "rc-checkbox": "~3.0.0",
                 "rc-collapse": "~3.4.2",
                 "rc-dialog": "~9.0.2",
-                "rc-drawer": "~6.1.0",
+                "rc-drawer": "~6.3.0",
                 "rc-dropdown": "~4.0.0",
-                "rc-field-form": "~1.27.0",
+                "rc-field-form": "~1.30.0",
                 "rc-image": "~5.13.0",
                 "rc-input": "~0.1.4",
                 "rc-input-number": "~7.3.9",
@@ -22055,12 +22055,12 @@
             }
         },
         "rc-drawer": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.1.6.tgz",
-            "integrity": "sha512-EBRFM9o3lPU5kYh8sFoXYA9KxpdT765HDqj/AbZWicXkhwEYUH7MjUH0ctenPCiHBxXQUgIUvK14+6rPuURd6w==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.3.0.tgz",
+            "integrity": "sha512-uBZVb3xTAR+dBV53d/bUhTctCw3pwcwJoM7g5aX+7vgwt2zzVzoJ6aqFjYJpBlZ9zp0dVYN8fV+hykFE7c4lig==",
             "requires": {
                 "@babel/runtime": "^7.10.1",
-                "@rc-component/portal": "^1.0.0-6",
+                "@rc-component/portal": "^1.1.1",
                 "classnames": "^2.2.6",
                 "rc-motion": "^2.6.1",
                 "rc-util": "^5.21.2"
@@ -22078,9 +22078,9 @@
             }
         },
         "rc-field-form": {
-            "version": "1.27.4",
-            "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
-            "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.30.0.tgz",
+            "integrity": "sha512-hCBa3/+m9SSuEPILSsxB/wd3ZFEmNTQfIhThhMaMp05fLwDDw+2K26lEZf5NuChQlx90VVNUOYmTslH6Ks4tpA==",
             "requires": {
                 "@babel/runtime": "^7.18.0",
                 "async-validator": "^4.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.12",
+    "version": "7.9.13",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,7 +75,7 @@
         "webpack-cli": "^3.3.12"
     },
     "peerDependencies": {
-        "antd": "^4.24.10",
+        "antd": "^4.24.11",
         "date-fns": "^2.29.3",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"

--- a/packages/ui/src/components/AnchorMenu/index.tsx
+++ b/packages/ui/src/components/AnchorMenu/index.tsx
@@ -6,6 +6,8 @@ import styles from './index.module.scss';
 
 const { Link } = Anchor;
 
+const DEFAULT_BOUND = 50;
+
 export interface IAnchorLink {
     href: string;
     title: string;
@@ -19,43 +21,29 @@ export interface IAnchorMenuProps extends AnchorProps {
 }
 
 const AnchorMenu = ({
-    affix,
-    bounds,
+    bounds = DEFAULT_BOUND,
     className,
     getContainer,
-    getCurrentAnchor,
     links = [],
-    offsetTop,
-    onChange,
-    prefixCls,
     scrollContainerId,
-    showInkInFixed,
-    targetOffset,
-}: IAnchorMenuProps) => {
+    ...rest
+}: IAnchorMenuProps): JSX.Element => {
     const scrollContainer = document.getElementById(scrollContainerId);
-
     const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
 
     const filteredLinks = links.filter((link) => !link.hidden);
 
-    /** by default use first href link */
-    const _getCurrentAnchor = (activeLink: string) => activeLink || (filteredLinks[0] && filteredLinks[0].href);
     const _getContainer = simplebarContent
         ? () => simplebarContent[simplebarContent.length - 1] as AnchorContainer
         : undefined;
+    // const _getContainer = scrollContainer ? () => scrollContainer : undefined;
 
-    /** all props are overridable by new props */
     return (
         <Anchor
-            affix={affix}
-            bounds={50}
+            bounds={bounds}
             className={`${styles.anchorMenu} ${className}`}
             getContainer={getContainer || _getContainer}
-            offsetTop={offsetTop}
-            onChange={onChange}
-            prefixCls={prefixCls}
-            showInkInFixed={showInkInFixed}
-            targetOffset={targetOffset}
+            {...rest}
         >
             {filteredLinks.map(({ href, title }: IAnchorLink, index: number) => (
                 <Link href={href} key={index} title={title} />

--- a/packages/ui/src/components/AnchorMenu/index.tsx
+++ b/packages/ui/src/components/AnchorMenu/index.tsx
@@ -20,31 +20,26 @@ export interface IAnchorMenuProps extends AnchorProps {
     links: IAnchorLink[];
 }
 
+/**
+ * Since antd 4.24.11 we can't set active link. We need a little workaround with bounds props
+ * we can't cache the scroll container html element, antd need to query it everytime on the scroll event
+ * Adding an active link will broke the scroll event
+ * TODO rewrite to antd 5.0
+ */
 const AnchorMenu = ({
     bounds = DEFAULT_BOUND,
     className,
-    getContainer,
     links = [],
     scrollContainerId,
     ...rest
 }: IAnchorMenuProps): JSX.Element => {
-    const scrollContainer = document.getElementById(scrollContainerId);
-    const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
-
     const filteredLinks = links.filter((link) => !link.hidden);
 
-    const _getContainer = simplebarContent
-        ? () => simplebarContent[simplebarContent.length - 1] as AnchorContainer
-        : undefined;
-    // const _getContainer = scrollContainer ? () => scrollContainer : undefined;
+    const _getContainer = () =>
+        document.querySelector(`#${scrollContainerId} .simplebar-content-wrapper:last-child`) as AnchorContainer;
 
     return (
-        <Anchor
-            bounds={bounds}
-            className={`${styles.anchorMenu} ${className}`}
-            getContainer={getContainer || _getContainer}
-            {...rest}
-        >
+        <Anchor bounds={bounds} className={`${styles.anchorMenu} ${className}`} getContainer={_getContainer} {...rest}>
             {filteredLinks.map(({ href, title }: IAnchorLink, index: number) => (
                 <Link href={href} key={index} title={title} />
             ))}

--- a/packages/ui/src/components/AnchorMenu/index.tsx
+++ b/packages/ui/src/components/AnchorMenu/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Anchor, AnchorProps } from 'antd';
+import Anchor, { AnchorProps } from 'antd/lib/anchor';
+import { AnchorContainer } from 'antd/lib/anchor/Anchor';
 
 import styles from './index.module.scss';
 
@@ -19,9 +20,9 @@ export interface IAnchorMenuProps extends AnchorProps {
 
 const AnchorMenu = ({
     affix,
-    getContainer,
     bounds,
     className,
+    getContainer,
     getCurrentAnchor,
     links = [],
     offsetTop,
@@ -33,20 +34,23 @@ const AnchorMenu = ({
 }: IAnchorMenuProps) => {
     const scrollContainer = document.getElementById(scrollContainerId);
 
+    const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
+
     const filteredLinks = links.filter((link) => !link.hidden);
 
     /** by default use first href link */
     const _getCurrentAnchor = (activeLink: string) => activeLink || (filteredLinks[0] && filteredLinks[0].href);
-    const _getContainer = scrollContainer ? () => scrollContainer : undefined;
+    const _getContainer = simplebarContent
+        ? () => simplebarContent[simplebarContent.length - 1] as AnchorContainer
+        : undefined;
 
     /** all props are overridable by new props */
     return (
         <Anchor
             affix={affix}
-            bounds={bounds}
+            bounds={50}
             className={`${styles.anchorMenu} ${className}`}
             getContainer={getContainer || _getContainer}
-            getCurrentAnchor={getCurrentAnchor || _getCurrentAnchor}
             offsetTop={offsetTop}
             onChange={onChange}
             prefixCls={prefixCls}

--- a/packages/ui/src/pages/EntityPage/EntityPage.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { AnchorContainer } from 'antd/lib/anchor/Anchor';
 
 import AnchorMenu from '../../components/AnchorMenu';
 import { IAnchorLink } from '../../components/AnchorMenu';
@@ -8,15 +9,26 @@ import ScrollContent from '../../layout/ScrollContent';
 import styles from './EntityPage.module.scss';
 
 export interface IEntityPage {
-    pageId: string;
-    links: IAnchorLink[];
-    data?: any;
-    loading: boolean;
-    emptyText?: string;
     children: React.ReactNode;
+    links: IAnchorLink[];
+    loading: boolean;
+    pageId: string;
+    bounds?: number;
+    data?: any;
+    emptyText?: string;
+    getContainer?: () => AnchorContainer;
 }
 
-const EntityPage: React.FC<IEntityPage> = ({ children, data, emptyText, links, loading, pageId }) => {
+const EntityPage: React.FC<IEntityPage> = ({
+    bounds,
+    children,
+    data,
+    emptyText,
+    getContainer,
+    links,
+    loading,
+    pageId,
+}) => {
     const [scrollContainerId, setScrollContainerId] = useState<string>('');
     const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
 
@@ -35,7 +47,13 @@ const EntityPage: React.FC<IEntityPage> = ({ children, data, emptyText, links, l
     return (
         <div className={styles.entityPageContainer}>
             <ScrollContent className={styles.scrollContent}>{children}</ScrollContent>
-            <AnchorMenu className={styles.anchorMenu} links={links} scrollContainerId={scrollContainerId} />
+            <AnchorMenu
+                bounds={bounds}
+                className={styles.anchorMenu}
+                getContainer={getContainer}
+                links={links}
+                scrollContainerId={pageId}
+            />
         </div>
     );
 };

--- a/packages/ui/src/pages/EntityPage/EntityPage.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityPage.tsx
@@ -14,19 +14,19 @@ export interface IEntityPage {
     loading: boolean;
     emptyText?: string;
     children: React.ReactNode;
-    preventUrlHash?: boolean;
 }
 
-const EntityPage: React.FC<IEntityPage> = ({ children, data, emptyText, links, loading, pageId = '' }) => {
-    const [scrollContainerId, setScrollContainerId] = useState<string>(pageId);
+const EntityPage: React.FC<IEntityPage> = ({ children, data, emptyText, links, loading, pageId }) => {
+    const [scrollContainerId, setScrollContainerId] = useState<string>('');
     const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
 
     useEffect(() => {
-        if (pageId && simplebarContent?.length) {
-            setScrollContainerId(pageId);
-            simplebarContent[simplebarContent.length - 1].setAttribute('id', pageId);
+        if (simplebarContent.length) {
+            const scrollContainerId = pageId;
+            setScrollContainerId(scrollContainerId);
+            simplebarContent[simplebarContent.length - 1].setAttribute('id', scrollContainerId);
         }
-    }, [simplebarContent, pageId]);
+    }, [scrollContainerId, simplebarContent, pageId]);
 
     if (!data && !loading) {
         return <Empty description={emptyText} imageType="row" size="large" />;

--- a/packages/ui/src/pages/EntityPage/EntityPage.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityPage.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { AnchorContainer } from 'antd/lib/anchor/Anchor';
+import React from 'react';
 
 import AnchorMenu from '../../components/AnchorMenu';
 import { IAnchorLink } from '../../components/AnchorMenu';
@@ -16,44 +15,17 @@ export interface IEntityPage {
     bounds?: number;
     data?: any;
     emptyText?: string;
-    getContainer?: () => AnchorContainer;
 }
 
-const EntityPage: React.FC<IEntityPage> = ({
-    bounds,
-    children,
-    data,
-    emptyText,
-    getContainer,
-    links,
-    loading,
-    pageId,
-}) => {
-    const [scrollContainerId, setScrollContainerId] = useState<string>('');
-    const simplebarContent = document.getElementsByClassName('simplebar-content-wrapper');
-
-    useEffect(() => {
-        if (simplebarContent.length) {
-            const scrollContainerId = pageId;
-            setScrollContainerId(scrollContainerId);
-            simplebarContent[simplebarContent.length - 1].setAttribute('id', scrollContainerId);
-        }
-    }, [scrollContainerId, simplebarContent, pageId]);
-
+const EntityPage: React.FC<IEntityPage> = ({ bounds, children, data, emptyText, links, loading, pageId }) => {
     if (!data && !loading) {
         return <Empty description={emptyText} imageType="row" size="large" />;
     }
 
     return (
-        <div className={styles.entityPageContainer}>
+        <div className={styles.entityPageContainer} id={pageId}>
             <ScrollContent className={styles.scrollContent}>{children}</ScrollContent>
-            <AnchorMenu
-                bounds={bounds}
-                className={styles.anchorMenu}
-                getContainer={getContainer}
-                links={links}
-                scrollContainerId={pageId}
-            />
+            <AnchorMenu bounds={bounds} className={styles.anchorMenu} links={links} scrollContainerId={pageId} />
         </div>
     );
 };

--- a/storybook/stories/Components/AnchorMenu/AnchorMenu.stories.tsx
+++ b/storybook/stories/Components/AnchorMenu/AnchorMenu.stories.tsx
@@ -3,24 +3,24 @@ import { Meta } from '@storybook/react/types-6-0';
 import AnchorMenu, { IAnchorLink } from '@ferlab/ui/components/AnchorMenu';
 
 export default {
-    title: "@ferlab/Components/Menu/AnchorMenu",
+    title: '@ferlab/Components/Menu/AnchorMenu',
     component: AnchorMenu,
-    decorators: [(Story) => <Story/>],
+    decorators: [(Story) => <Story />],
     argTypes: {
         className: {
-            control: 'text'
+            control: 'text',
         },
         scrollContainerId: {
-            control: 'text'
+            control: 'text',
         },
         preventUrlHash: {
-            control: 'boolean'
+            control: 'boolean',
         },
         links: {
-            control: 'array'
+            control: 'array',
         },
     },
-} as Meta
+} as Meta;
 
 const scrollContainerId = 'scrollContainerId';
 const links: IAnchorLink[] = [
@@ -29,28 +29,26 @@ const links: IAnchorLink[] = [
     { href: '#Blank3', title: 'Blank3' },
     { href: '#Blank4', title: 'Blank4' },
     { href: '#Blank5', title: 'Blank5' },
-]
+];
 
-const Blank = ({ id, title }: { id: string, title: string }) => (
+const Blank = ({ id, title }: { id: string; title: string }) => (
     <div id={id} style={{ height: 800, width: 600, backgroundColor: 'white', margin: 20, padding: 20 }}>
         {title}
     </div>
-)
+);
 
 export const AnchorMenuStory = () => (
     <>
         <h3>Anchor Menu Story</h3>
         <div style={{ display: 'flex', justifyContent: 'center' }}>
             <div id={scrollContainerId} style={{ overflow: 'auto' }}>
-                {
-                    links.map(({ href, title }, index) =>
-                        <Blank key={index} id={href.replace('#', '')} title={title}  />)
-                }
+                <div className="simplebar-content-wrapper">
+                    {links.map(({ href, title }, index) => (
+                        <Blank key={index} id={href.replace('#', '')} title={title} />
+                    ))}
+                </div>
             </div>
-            <AnchorMenu
-                links={links}
-                scrollContainerId={scrollContainerId}
-            />
+            <AnchorMenu links={links} scrollContainerId={scrollContainerId} />
         </div>
     </>
 );
@@ -61,24 +59,20 @@ const hiddenLinks: IAnchorLink[] = [
     { href: '#Blank3', title: 'Blank3' },
     { href: '#Blank4', title: 'Blank4', hidden: true },
     { href: '#Blank5', title: 'Blank5', hidden: true },
-]
-
+];
 
 export const AnchorMenuWithHiddenValueStory = () => (
     <>
         <h3>Anchor Menu With link 4 and 5 Hidden Story</h3>
         <div style={{ display: 'flex', justifyContent: 'center' }}>
             <div id={scrollContainerId} style={{ overflow: 'auto' }}>
-                {
-                    hiddenLinks.map(({ href, title }, index) =>
-                        <Blank key={index} id={href.replace('#', '')} title={title}  />)
-                }
+                <div className="simplebar-content-wrapper">
+                    {hiddenLinks.map(({ href, title }, index) => (
+                        <Blank key={index} id={href.replace('#', '')} title={title} />
+                    ))}
+                </div>
             </div>
-            <AnchorMenu
-                links={hiddenLinks}
-                scrollContainerId={scrollContainerId}
-            />
+            <AnchorMenu links={hiddenLinks} scrollContainerId={scrollContainerId} />
         </div>
     </>
 );
-


### PR DESCRIPTION
# FIX : scroll page in anchor menu

- closes [FLUI-74](https://ferlab-crsj.atlassian.net/browse/FLUI-74) / [SJIP-511](https://d3b.atlassian.net/browse/SJIP-511)

## Description

When you scroll in an entity page with anchor menu, the menu highlight need to follow the scroll.
We add a comment to explain the workaround choose for this fix.
The documentation is [here](https://github.com/ant-design/ant-design/blob/4.x-stable/components/anchor/Anchor.tsx).
The issue is this part of antd code because if getContainer is a function like we had before we return.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/bde2de1f-fe9d-4ac0-966d-ede5564544b7)

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
[Screencast from 06-29-23 15:20:31.webm](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/c24f0f31-6f9d-48a6-a9dc-abc59fed2af9)

### After
[Screencast from 06-29-23 15:18:53.webm](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/27177f41-5440-4f6b-9784-a9259de4fa5b)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
