### PR TITLE
feat(sqon): FLUI-79 add pivot for nested sqon

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.15 2023-07-06
+- fix: FLUI-79 update sqon to add pivot props when a field is nested
+
 ### 7.9.14 2023-07-06
 - fix: CLIN-2050 updated GridCard props type
 
@@ -255,4 +258,3 @@
 
 - fix: Reformat generated code to use @ferlab/ui/core/X instead of .../lib/esnext/X
 - feat: Add StackLayout
-

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.14",
+    "version": "7.10.0-rc1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
# FEAT 

- closes #[79](https://ferlab-crsj.atlassian.net/browse/FLUI-79)

## Description
Ajout de la notion des nesteds components dans le query builder. Dans CLIN, un pivot était forcé sur [certaines query](https://github.com/Ferlab-Ste-Justine/clin-portal-ui/blob/af73fd9c8fd11fde43646d91c7a1016066ae0ec8/src/views/Snv/utils/helper.ts#L35-L35). Maintenant, il suffit de passer la liste des extends mappings. On y detecte les champs "nested" et ajoute le premier pivot qu'on trouve un champs considéré comme nested.

**Attention: il afin de normalizer nos types, il faut s'assure que VariantMapping est un `IExtendedMappingResults`**
```
  import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
  ...
  const variantResolvedSqon = resolveSyntheticSqon(queryList, activeQuery, variantMapping);
```

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/50c228ec-6ba4-4b72-bd58-187c6e20560d)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/31151fbf-24d0-489e-9c4b-308855221600)


