### PR TITLE
fix: CLIN-2050 GridCard type fixed content

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.9.14 2023-07-06
+- fix: CLIN-2050 updated GridCard props type
+
 ### 7.9.13 2023-06-29
 - fix: FLUI-74/SJIP-511 anchor menu higlight follow scroll
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.9.14-rc1",
+    "version": "7.9.14",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/view/v2/GridCard/GridCard.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCard.tsx
@@ -7,7 +7,7 @@ import ConditionalWrapper from '../../../components/utils/ConditionalWrapper';
 
 import styles from './Gridcard.module.scss';
 
-export type TGridCard = CardProps & {
+export type TGridCard = Omit<CardProps, 'content'> & {
     footer?: React.ReactNode;
     content: React.ReactNode;
     theme?: 'shade' | 'light';


### PR DESCRIPTION
# FIX | FEAT | REFACTOR | PERF | DOCS : TITLE

- closes #CLIN-2050

## Description
GridCard props type was preventing CLIN to build when specifying JSX.Element as part of the `content` props

[JIRA LINK]

Acceptance Criterias
Shouldn't have any effect on the app but should statisfy compiler when building projects using GridCard component

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
