### PR TITLE
feat(resizablegrid): SKFP-675 add truncable title on card header, fix…

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,5 +1,6 @@
 ### 7.11.1 2023-07-10
 - fix: CLIN-1763 assignement style + functionality 
+- feat: SKFP-675 add truncable title on card header, fix resizable card tooltip
 
 ### 7.11.0 2023-07-06
 - fix: SKFP-672 the user doesn't need to reset if a card is now resizable or static

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.11.1",
+    "version": "7.11.1-rc4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.11.1",
+            "version": "7.11.1-rc4",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.11.1-rc3",
+    "version": "7.11.1-rc4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { CloseOutlined, DownloadOutlined } from '@ant-design/icons';
-import { Button, Dropdown, Modal } from 'antd';
+import { Button, Dropdown, Modal, Tooltip } from 'antd';
 import d3ToPng from 'd3-svg-to-png';
 import { format } from 'date-fns';
 import { v4 } from 'uuid';
@@ -20,6 +20,7 @@ type TDictionary = {
         data?: string;
         svg?: string;
         png?: string;
+        removeChart?: string;
     };
 };
 
@@ -64,6 +65,7 @@ const EXPORT_SETTINGS = {
     scale: 1,
 };
 
+const CARD_HEADER_TITLE_TRUNCATE_THRESHOLD_WIDTH = 75;
 const DOWNLOAD_DELAY = 250;
 const DEFAULT_TSV_HEADERS = ['Value', 'Count', 'Frequency'];
 const DEFAULT_TSV_CONTENT_MAP = ['label', 'value', 'frequency'];
@@ -133,18 +135,20 @@ const ResizableGridCard = ({
     const fileNameDateFormat = dictionary?.download?.fileNameDateFormat ?? DEFAULT_FILENAME_DATE_FORMAT;
     const menuItems = populateMenuItems(downloadSettings, dictionary);
     const extra = [
-        <Button
-            className={styles.button}
-            icon={<CloseOutlined height={11} width={11} />}
-            key="remove-button"
-            onClick={() => {
-                if (id) {
-                    context[gridUID].onCardRemoveConfigUpdate(id);
-                }
-            }}
-            size="small"
-            type="text"
-        />,
+        <Tooltip title={`${dictionary?.download?.removeChart ?? 'Remove chart'}`}>
+            <Button
+                className={styles.button}
+                icon={<CloseOutlined height={11} width={11} />}
+                key="remove-button"
+                onClick={() => {
+                    if (id) {
+                        context[gridUID].onCardRemoveConfigUpdate(id);
+                    }
+                }}
+                size="small"
+                type="text"
+            />
+        </Tooltip>,
     ];
 
     if (menuItems.length > 0) {
@@ -247,6 +251,7 @@ const ResizableGridCard = ({
                         extraClassName={styles.extra}
                         id={headerTitle}
                         title={headerTitle}
+                        titleTruncateThresholdWidth={CARD_HEADER_TITLE_TRUNCATE_THRESHOLD_WIDTH}
                         withHandle
                     />
                 }

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardHeader.module.scss
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardHeader.module.scss
@@ -5,6 +5,11 @@
   align-items: center;
   justify-content: space-between;
   font-size: 12px !important;
+  width: 100%;
+
+  .cardHeadererContent {
+    overflow: hidden;
+  }
 
   .dragHandle {
     font-size: 12px;
@@ -21,9 +26,16 @@
     color: $body-2;
     font-size: 12px;
   }
+
+  .titleContainer {
+    overflow: hidden;
+    width: 100%;
+  }
 }
 
 .infoPopoverOverlay {
   max-width: 350px;
 }
+
+
 

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from 'react';
+import { MutableRefObject, ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import React from 'react';
 import { HolderOutlined, InfoCircleOutlined } from '@ant-design/icons';
-import { Popover, PopoverProps, Space, Typography } from 'antd';
+import { Popover, PopoverProps, Space, Tooltip, Typography } from 'antd';
 import cx from 'classnames';
 
 import DragHandle from '../../../../layout/SortableGrid/DragHandle';
@@ -15,31 +15,69 @@ interface OwnProps {
     extraClassName?: string;
     extra?: ReactNode[];
     withHandle?: boolean;
+    titleTruncateThresholdWidth?: number;
 }
 
 const { Title } = Typography;
 
-const GridCardHeader = ({ id, title, extraClassName = '', extra = [], withHandle = false, infoPopover }: OwnProps) => (
-    <Title className={styles.cardHeader} level={4}>
-        <Space align="center" className={styles.title} direction="horizontal" size={5}>
-            {withHandle && (
-                <DragHandle className={styles.dragHandle} id={id}>
-                    <HolderOutlined />
-                </DragHandle>
-            )}
-            {title}
-            {infoPopover && (
-                <Popover
-                    {...infoPopover}
-                    className={cx(styles.infoPopover, infoPopover.className)}
-                    overlayClassName={cx(styles.infoPopoverOverlay, infoPopover.overlayClassName)}
-                >
-                    <InfoCircleOutlined className={styles.infoIcon} />
-                </Popover>
-            )}
-        </Space>
-        <div className={extraClassName}>{extra}</div>
-    </Title>
-);
+const GridCardHeader = ({
+    id,
+    title,
+    extraClassName = '',
+    extra = [],
+    withHandle = false,
+    infoPopover,
+    titleTruncateThresholdWidth,
+}: OwnProps): JSX.Element => {
+    const [truncated, setTruncated] = useState(false);
+    const [titleWidth, setTitleWidth] = useState('100%');
+    const headerContainerRef = useRef() as MutableRefObject<HTMLSpanElement>;
+
+    // titleTruncateThresholdWidth allow text to be truncate. antd absolutly needs a
+    // a width to be able to works. Only active it when needed since useLayoutEffect
+    // can be a performance pitfall. A value needs to be passed since our div can
+    // be bigger than our header width.
+    if (titleTruncateThresholdWidth) {
+        useLayoutEffect(() => {
+            if (!headerContainerRef?.current) {
+                return;
+            }
+
+            const headerWidth = headerContainerRef.current.clientWidth;
+            setTitleWidth(`${headerWidth - titleTruncateThresholdWidth}px`);
+        });
+    }
+
+    return (
+        <Title className={styles.cardHeader} level={4} ref={headerContainerRef}>
+            <Space align="center" className={styles.cardHeadererContent} direction="horizontal" size={5}>
+                {withHandle && (
+                    <DragHandle className={styles.dragHandle} id={id}>
+                        <HolderOutlined />
+                    </DragHandle>
+                )}
+                {
+                    <div className={styles.titleContainer} style={{ width: titleWidth }}>
+                        <Tooltip title={truncated ? title : undefined}>
+                            <Typography.Text ellipsis={{ onEllipsis: setTruncated }} style={{ width: titleWidth }}>
+                                {title}
+                            </Typography.Text>
+                        </Tooltip>
+                    </div>
+                }
+                {infoPopover && (
+                    <Popover
+                        {...infoPopover}
+                        className={cx(styles.infoPopover, infoPopover.className)}
+                        overlayClassName={cx(styles.infoPopoverOverlay, infoPopover.overlayClassName)}
+                    >
+                        <InfoCircleOutlined className={styles.infoIcon} />
+                    </Popover>
+                )}
+            </Space>
+            <div className={extraClassName}>{extra}</div>
+        </Title>
+    );
+};
 
 export default GridCardHeader;


### PR DESCRIPTION
… resizable card tooltip

# FEAT 

- closes #[675](https://d3b.atlassian.net/browse/SKFP-675)

## Description
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6f80d485-5306-4c1b-8d3c-02d7cdef67ee)

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
Les captures d'écrans sont pris sur KF

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/fc65be8e-48ca-42c6-9e85-13d8ba5c4292)


https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/a1cbc30a-b704-4830-807c-e3547ee9a319


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
