### PR TITLE
feat: CLIN-2207 ajout extraCountInfo header protable

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,4 +1,7 @@
 ### 7.13.5 2023-08-31
+- feat: CLIN-2207 Add extraCountInfo header proTable
+
+### 7.13.5 2023-08-31
 - feat: CLIN-2197 Add custom Pagination in proTable
 
 ### 7.13.3 2023-08-31

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.13.5",
+    "version": "7.13.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Header/index.module.scss
+++ b/packages/ui/src/components/ProTable/Header/index.module.scss
@@ -2,6 +2,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  .extraCountInfo{
+    display: inline-block;
+
+    :global(.ant-divider) {
+      height: 22px;
+      margin: 0 12px;
+    }
+
+    > div {
+      display: inline-block;
+    }
+  }
 }
 
 .ProTableHeaderSelectAllBtn {

--- a/packages/ui/src/components/ProTable/Header/index.tsx
+++ b/packages/ui/src/components/ProTable/Header/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Space } from 'antd';
+import { Divider, Space } from 'antd';
 
 import { IProTableDictionary } from '../types';
 
@@ -22,10 +22,12 @@ interface OwnProps {
     onSelectAllResults?: () => void;
     onClearSelection?: () => void;
     className?: string;
+    extraCountInfo?: React.ReactNode[];
 }
 
 const TableHeader = ({
     extra = [],
+    extraCountInfo = [],
     extraSpacing = 12,
     pageIndex,
     pageSize,
@@ -40,24 +42,33 @@ const TableHeader = ({
     className,
 }: OwnProps) => (
     <div className={className || styles.ProTableHeader}>
-        {selectedRowCount > 0 ? (
-            <SelectedCount
-                dictionnary={dictionary}
-                onClear={onClearSelection}
-                onSelectAll={onSelectAllResults}
-                selectedAllPage={selectedAllPage}
-                selectedAllResults={selectedAllResults}
-                selectedRowCount={selectedRowCount}
-            />
-        ) : (
-            <ItemsCount
-                dictionnary={dictionary}
-                hidden={hideItemsCount}
-                page={pageIndex}
-                size={pageSize}
-                total={total}
-            />
-        )}
+        <div>
+            {selectedRowCount > 0 ? (
+                <SelectedCount
+                    dictionnary={dictionary}
+                    onClear={onClearSelection}
+                    onSelectAll={onSelectAllResults}
+                    selectedAllPage={selectedAllPage}
+                    selectedAllResults={selectedAllResults}
+                    selectedRowCount={selectedRowCount}
+                />
+            ) : (
+                <ItemsCount
+                    dictionnary={dictionary}
+                    hidden={hideItemsCount}
+                    page={pageIndex}
+                    size={pageSize}
+                    total={total}
+                />
+            )}
+            {extraCountInfo &&
+                extraCountInfo.map((element, index) => (
+                    <div className={styles.extraCountInfo} key={index}>
+                        <Divider type="vertical" />
+                        <div>{element}</div>
+                    </div>
+                ))}
+        </div>
         <Space size={extraSpacing}>
             {extra.map((element, index) => (
                 <div key={index}>{element}</div>

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -92,6 +92,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
         enableColumnSort: false,
         enableTableExport: false,
         extra: [],
+        extraCountInfo: [],
         extraSpacing: 12,
         itemCount: {
             pageIndex: 1,
@@ -271,6 +272,7 @@ const ProTable = <RecordType extends object & { key: string } = any>({
                 className={tableHeaderClassName}
                 dictionary={dictionary}
                 extra={getExtraConfig()}
+                extraCountInfo={headerConfig.extraCountInfo}
                 extraSpacing={headerConfig.extraSpacing}
                 hideItemsCount={headerConfig.hideItemsCount}
                 onClearSelection={() => {

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -104,6 +104,7 @@ export type THeaderConfig<RecordType> = {
     marginBtm?: number;
     extraSpacing?: number;
     extra?: ReactNode[];
+    extraCountInfo?: ReactNode[];
     enableTableExport?: boolean;
     enableColumnSort?: boolean;
     onSelectedRowsChange?: (selectedKeys: any[], selectedRows: RecordType[]) => void;


### PR DESCRIPTION
# FEAT : ajout extraCountInfo header protable

- closes #CLIN-2207

## Description
Ajoute la possibilité d'ajouter plus d'info a droite du nombre de résultat

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2207)

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/52966302/8b633c78-4b54-47c9-be9d-fbf566b760ae)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/52966302/3122f266-7a96-47dc-9999-ffa256f7cb6b)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
