### PR TITLE
feat(consequence): skfp-850 add consequences cell component

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.14.0 2023-11-01
+- feat: SKFP-850 Add consequences cell component
+
 ### 7.13.9 2023-10-23
 - feat: SJIP-574 Update list item action button style
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.13.9",
+    "version": "7.14.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.13.9",
+            "version": "7.14.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.13.9",
+    "version": "7.14.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Consequences/Cell/index.module.scss
+++ b/packages/ui/src/components/Consequences/Cell/index.module.scss
@@ -1,0 +1,40 @@
+@import 'colors';
+
+.stackLayout {
+  min-width: 375px;
+}
+
+.consequenceUl {
+  list-style: none;
+  padding: 0;
+}
+
+.highImpact {
+  fill: $red-5;
+}
+
+.lowImpact {
+  fill: $green-6;
+}
+
+.moderateImpact {
+  fill: $orange-5;
+}
+
+.modifierImpact {
+  fill: $gray-6;
+}
+
+.detail {
+  padding-right: 12px;
+}
+
+.bullet {
+  margin-right: 8px;
+  min-width: 10px;
+  min-height: 10px;
+}
+
+.symbol {
+  padding-right: 8px;
+}

--- a/packages/ui/src/components/Consequences/Cell/index.test.tsx
+++ b/packages/ui/src/components/Consequences/Cell/index.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { IArrangerEdge } from '../../../graphql/types';
+
+import ConsequencesCell, { IConsequenceEntity } from '.';
+
+const data = [
+    {
+        node: {
+            consequence: ['stop gained'],
+            hgvsp: 'ENSP00000361408.3:p.Arg151Ter',
+            picked: true,
+            vep_impact: 'HIGH',
+        },
+    },
+    {
+        node: {
+            consequence: ['synonymous'],
+            hgvsp: 'ENSP00000361411.3:p.Pro210=',
+            picked: false,
+            vep_impact: 'LOW',
+        },
+    },
+] as IArrangerEdge<IConsequenceEntity>[];
+
+const unpickedData = [
+    {
+        node: {
+            consequence: ['stop gained'],
+            hgvsp: 'ENSP00000361408.3:p.Arg151Ter',
+            picked: false,
+            vep_impact: 'HIGH',
+        },
+    },
+    {
+        node: {
+            consequence: ['synonymous'],
+            hgvsp: 'ENSP00000361411.3:p.Pro210=',
+            picked: false,
+            vep_impact: 'LOW',
+        },
+    },
+] as IArrangerEdge<IConsequenceEntity>[];
+
+describe('ConsequencesCell', () => {
+    test('make sure ConsequencesCell is correctly rendered', () => {
+        render(<ConsequencesCell consequences={data} emptyText="No data Available" symbol="ZCCHC24" />);
+        expect(screen.queryByText('Stop gained')).toBeTruthy();
+        expect(screen.queryByText('ZCCHC24')).toBeTruthy();
+        expect(screen.queryByText('p.Arg151Ter')).toBeTruthy();
+    });
+    test('make sure ConsequencesCell manage picked false', () => {
+        render(<ConsequencesCell consequences={unpickedData} emptyText="No data Available" symbol="ZCCHC24" />);
+        expect(screen.queryByText('No data Available')).toBeTruthy();
+    });
+    test('make sure ConsequencesCell manage empty consequence', () => {
+        render(<ConsequencesCell consequences={unpickedData} emptyText="No data Available" symbol="ZCCHC24" />);
+        expect(screen.queryByText('No data Available')).toBeTruthy();
+    });
+    test('make sure ConsequencesCell manage empty NO_GENE', () => {
+        render(<ConsequencesCell consequences={data} emptyText="No data Available" symbol="NO_GENE" />);
+    });
+});

--- a/packages/ui/src/components/Consequences/Cell/index.tsx
+++ b/packages/ui/src/components/Consequences/Cell/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { IArrangerEdge } from '../../../graphql/types';
+import StackLayout from '../../../layout/StackLayout';
+import { removeUnderscoreAndCapitalize, toKebabCase } from '../../../utils/stringUtils';
+import Empty from '../../Empty';
+import ExternalLink from '../../ExternalLink';
+import HighBadgeIcon from '../Icons/HighBadgeIcon';
+import LowBadgeIcon from '../Icons/LowBadgeIcon';
+import ModerateBadgeIcon from '../Icons/ModerateBadgeIcon';
+import ModifierBadgeIcon from '../Icons/ModifierBadgeIcon';
+
+import style from './index.module.scss';
+
+const NO_GENE = 'NO_GENE';
+
+export enum Impact {
+    High = 'HIGH',
+    Moderate = 'MODERATE',
+    Low = 'LOW',
+    Modifier = 'MODIFIER',
+}
+
+export interface IConsequenceEntity {
+    id: string;
+    picked: boolean;
+    consequence: string[];
+    hgvsp: string;
+    vep_impact: Impact;
+}
+
+export type TConsequencesCell = {
+    consequences: IArrangerEdge<IConsequenceEntity>[];
+    symbol: string;
+    emptyText: string;
+};
+
+const impactToColorClassName = Object.freeze({
+    [Impact.High]: <HighBadgeIcon className={`${style.bullet} ${style.highImpact}`} />,
+    [Impact.Low]: <LowBadgeIcon className={`${style.bullet} ${style.lowImpact}`} />,
+    [Impact.Moderate]: <ModerateBadgeIcon className={`${style.bullet} ${style.moderateImpact}`} />,
+    [Impact.Modifier]: <ModifierBadgeIcon className={`${style.bullet} ${style.modifierImpact}`} />,
+});
+
+const pickImpactBadge = (impact: Impact) => impactToColorClassName[impact];
+
+const ConsequencesCell = ({ consequences, emptyText, symbol }: TConsequencesCell): JSX.Element | null => {
+    const pickedEdge = consequences.find((c) => c.node.picked);
+    if (!pickedEdge) {
+        return <Empty align="left" description={emptyText} noPadding showImage={false} size="mini" />;
+    }
+
+    const picked = pickedEdge?.node;
+    if (!picked?.consequence) {
+        return <Empty align="left" description={emptyText} noPadding showImage={false} size="mini" />;
+    }
+
+    if (symbol === NO_GENE) {
+        return <Empty align="left" description={emptyText} noPadding showImage={false} size="mini" />;
+    }
+
+    return (
+        <StackLayout center className={style.stackLayout} key={'1'}>
+            {pickImpactBadge(picked.vep_impact)}
+            <span className={style.detail} key="detail">
+                {removeUnderscoreAndCapitalize(picked.consequence[0])}
+            </span>
+            {symbol && (
+                <span className={style.symbol} key={toKebabCase(symbol)}>
+                    <ExternalLink href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${symbol}`}>
+                        {symbol}
+                    </ExternalLink>
+                </span>
+            )}
+            {picked.hgvsp && <span>{picked.hgvsp.split(':')[1]}</span>}
+        </StackLayout>
+    );
+};
+
+export default ConsequencesCell;

--- a/packages/ui/src/components/Consequences/Icons/HighBadgeIcon.tsx
+++ b/packages/ui/src/components/Consequences/Icons/HighBadgeIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { IIconProps } from '../../Icons/type';
+
+const HighBadgeIcon = ({ className = '', height = 10, width = 10 }: IIconProps) => (
+    <svg
+        className={className}
+        fill="currentColor"
+        height={height}
+        viewBox="0 0 10 10"
+        width={width}
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path d="M5 1.00012L0 9.00012H10L5 1.00012Z" />
+    </svg>
+);
+
+export default HighBadgeIcon;

--- a/packages/ui/src/components/Consequences/Icons/LowBadgeIcon.tsx
+++ b/packages/ui/src/components/Consequences/Icons/LowBadgeIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { IIconProps } from '../../Icons/type';
+
+const LowBadgeIcon = ({ className = '', height = 10, width = 10 }: IIconProps) => (
+    <svg
+        className={className}
+        fill="currentColor"
+        height={height}
+        viewBox="0 0 10 10"
+        width={width}
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path d="M5 9.00012L0 1.00012H10L5 9.00012Z" />
+    </svg>
+);
+
+export default LowBadgeIcon;

--- a/packages/ui/src/components/Consequences/Icons/ModerateBadgeIcon.tsx
+++ b/packages/ui/src/components/Consequences/Icons/ModerateBadgeIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { IIconProps } from '../../Icons/type';
+
+const ModerateBadgeIcon = ({ className = '', height = 10, width = 10 }: IIconProps) => (
+    <svg
+        className={className}
+        fill="currentColor"
+        height={height}
+        viewBox="0 0 10 10"
+        width={width}
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path d="M10 5.00012L5 10.0001L0 5.00012L5 0.00012207L10 5.00012Z" />
+    </svg>
+);
+
+export default ModerateBadgeIcon;

--- a/packages/ui/src/components/Consequences/Icons/ModifierBadgeIcon.tsx
+++ b/packages/ui/src/components/Consequences/Icons/ModifierBadgeIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { IIconProps } from '../../Icons/type';
+
+const ModifierBadgeIcon = ({ className = '', height = 10, width = 10 }: IIconProps) => (
+    <svg
+        className={className}
+        fill="currentColor"
+        height={height}
+        viewBox="0 0 10 10"
+        width={width}
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <circle cx="5" cy="5.00012" r="4" />
+    </svg>
+);
+
+export default ModifierBadgeIcon;

--- a/storybook/stories/Components/Consequences/Cell/ConsequencesCell.stories.tsx
+++ b/storybook/stories/Components/Consequences/Cell/ConsequencesCell.stories.tsx
@@ -1,0 +1,142 @@
+
+import React from "react";
+import { Meta } from "@storybook/react/types-6-0";
+import ConsequencesCell, { IConsequenceEntity } from '@ferlab/ui/components/Consequences/Cell';
+import { IArrangerEdge } from "@ferlab/ui/graphql/types";
+
+const data = [
+    {
+        "node": {
+            "aa_change": "p.Arg151Ter",
+            "amino_acids": {
+                "reference": "R",
+                "variant": "*"
+            },
+            "canonical": false,
+            "cdna_position": "502",
+            "cds_position": "451",
+            "coding_dna_change": "c.451G>A",
+            "codons": {
+                "reference": "Cga",
+                "variant": "Tga"
+            },
+            "consequence": [
+                "stop gained"
+            ],
+            "conservations": {
+                "phyloP100way_vertebrate": -3.864,
+                "phyloP17way_primate": -1.463
+            },
+            "ensembl_feature_id": "ENST00000372333",
+            "ensembl_transcript_id": "ENST00000372333",
+            "exon": {
+                "rank": "4",
+                "total": 4
+            },
+            "feature_type": "Transcript",
+            "hgvsc": "ENST00000372333.3:c.451C>T",
+            "hgvsp": "ENSP00000361408.3:p.Arg151Ter",
+            "impact_score": 4,
+            "intron": null,
+            "mane_plus": false,
+            "mane_select": false,
+            "picked": true,
+            "predictions": {
+                "cadd_phred": 0.219,
+                "cadd_score": -0.373276,
+                "dann_score": 0.9572040498913029,
+                "fathmm_pred": null,
+                "fathmm_score": null,
+                "lrt_pred": null,
+                "lrt_score": null,
+                "polyphen2_hvar_pred": null,
+                "polyphen2_hvar_score": null,
+                "revel_score": null,
+                "sift_pred": null,
+                "sift_score": null
+            },
+            "protein_position": "151",
+            "refseq_mrna_id": null,
+            "strand": "-1",
+            "uniprot_id": null,
+            "vep_impact": "HIGH"
+        }
+    },
+    {
+        "node": {
+            "aa_change": "p.Pro210=",
+            "amino_acids": {
+                "reference": "P",
+                "variant": null
+            },
+            "canonical": true,
+            "cdna_position": "817",
+            "cds_position": "630",
+            "coding_dna_change": "c.630G>A",
+            "codons": {
+                "reference": "ccC",
+                "variant": "ccT"
+            },
+            "consequence": [
+                "synonymous"
+            ],
+            "conservations": null,
+            "ensembl_feature_id": "ENST00000372336",
+            "ensembl_transcript_id": "ENST00000372336",
+            "exon": {
+                "rank": "4",
+                "total": 4
+            },
+            "feature_type": "Transcript",
+            "hgvsc": "ENST00000372336.3:c.630C>T",
+            "hgvsp": "ENSP00000361411.3:p.Pro210=",
+            "impact_score": 2,
+            "intron": null,
+            "mane_plus": false,
+            "mane_select": true,
+            "picked": false,
+            "predictions": null,
+            "protein_position": "210",
+            "refseq_mrna_id": [
+                "NM_153367"
+            ],
+            "strand": "-1",
+            "uniprot_id": "A0A024QZP0",
+            "vep_impact": "LOW"
+        }
+    }
+] as IArrangerEdge<IConsequenceEntity>[];
+
+export default {
+    title: "@ferlab/Components/Consequences/Cell",
+    component: ConsequencesCell,
+    decorators: [
+        (Story) => (
+            <>
+                <h2>{Story}</h2>
+                <Story />
+            </>
+        ),
+    ],
+    argTypes: {
+        title: {
+            control: "string",
+        },
+    },
+} as Meta;
+
+export const ConsequencesCellStory = () => (
+<>
+  <h3>Consequences Cell with empty data</h3>
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+      <ConsequencesCell consequences={data} symbol="ZCCHC24" emptyText="No data available" />
+    </div>
+</>);
+
+export const ConsequencesCellWitNO_GENEStory = () => (
+<>
+  <h3>Consequences Cell with NO_GENE symbol</h3>
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+    <ConsequencesCell consequences={data} symbol="NO_GENE" emptyText="No data available" />
+    </div>
+</>);


### PR DESCRIPTION
# FEAT and FIX

- closes #[850](https://d3b.atlassian.net/browse/SKFP-850)

## Description
Since both Include and Kids-First use ConsequencesCell and there was bugfix to be done, I decided to port them on the ferlab-ui to prevent multi-code maintenance on both side.

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/e476ce86-e524-4817-bf77-72798b1fc60d)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/eeb3429f-e1b5-49aa-b6dd-fb4aec29c052)


