### PR TITLE
fix(filter): SKFP-831 manage no data in QB for range filter

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,10 +1,13 @@
+### 7.14.6 2023-11-08
+- fix: SKFP-831 manage no data in range filter in QB
+
 ### 7.14.5 2023-11-08
 - fix: SKFP-852 fix unnecessary breakpoint change for grid-layout
 
 ### 7.14.4 2023-11-08
 - fix: SKFP-852 fix infinite loop on page summary
 
-### 7.14.2 2023-11-06
+### 7.14.3 2023-11-06
 - fix: SJIP-582 extract upload utils method
 
 ### 7.14.2 2023-11-06

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.3",
+    "version": "7.14.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.14.3",
+            "version": "7.14.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.5",
+    "version": "7.14.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/FilterSelector.tsx
+++ b/packages/ui/src/components/filters/FilterSelector.tsx
@@ -22,6 +22,7 @@ const FilterSelector = ({
     filterGroup,
     filters,
     maxShowing,
+    noDataInputOption,
     onChange,
     searchInputVisible,
     selectedFilters,
@@ -36,7 +37,7 @@ const FilterSelector = ({
         case VisualType.Toggle:
             return <ToggleFilter {...commonProps} filters={filters} />;
         case VisualType.Range:
-            return <RangeFilter {...commonProps} filters={filters} />;
+            return <RangeFilter {...commonProps} filters={filters} noDataOption={noDataInputOption} />;
         case VisualType.Text:
             return <TextInputFilter {...commonProps} filters={filters} />;
         case VisualType.Checkbox:

--- a/packages/ui/src/components/filters/RangeFilter.tsx
+++ b/packages/ui/src/components/filters/RangeFilter.tsx
@@ -34,6 +34,7 @@ export type RangeFilterProps = {
     onChange: onChangeType<IFilterRange>;
     selectedFilters?: IFilter[];
     dictionary?: IDictionary | Record<string, never>;
+    noDataOption?: boolean;
 };
 
 const DEFAULT_STEP = 1;
@@ -147,13 +148,14 @@ const RangeFilter = ({
     dictionary,
     filterGroup,
     filters,
+    noDataOption,
     onChange,
     selectedFilters,
 }: RangeFilterProps): React.ReactElement | null => {
     const { config: range } = filterGroup;
     const currentFilter: IFilter<IFilterRange> = filters[0];
     const rangeTypes = filterGroup.config?.rangeTypes;
-    const noDataInputOption = filterGroup.config?.noDataInputOption ?? true;
+    const noDataInputOption = noDataOption != undefined ? noDataOption : filterGroup.config?.noDataInputOption ?? true;
     const defaultOperators = getDefaultOperatorList(
         dictionary,
         filterGroup.config?.defaultOperator || RangeOperators['<'],


### PR DESCRIPTION
# FIX : Manage no data in QB for range filter

## Description

[SKFP-831](https://d3b.atlassian.net/browse/SKFP-831)

Acceptance Criterias
Display no data option in query pill dropdown in query builder according to filter group options.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="934" alt="Capture d’écran, le 2023-11-14 à 16 39 34" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/115b81e9-858a-4d3e-a46b-12c2f86bf297">

### After
<img width="934" alt="Capture d’écran, le 2023-11-14 à 16 38 40" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/5259dbde-a931-441c-ab94-ba70040e26c2">
<img width="877" alt="Capture d’écran, le 2023-11-14 à 16 38 14" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/577fede3-f49b-4d97-975d-1b0ff09f2b8b">

