### PR TITLE
fix(grid): SKFP-852 prevent save while the grid is still loading

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.14.8 2023-11-08
+- fix: SKFP-852 prevent the grid to be saved while the grid is still loading
+
 ### 7.14.7 2023-11-08
 - fix: SKFP-852 fix an issue where the config is corrumpted the first time we open the grid
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.7",
+    "version": "7.14.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.14.7",
+            "version": "7.14.8",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.7",
+    "version": "7.14.8",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
# FIX 

- closes #[852](https://d3b.atlassian.net/browse/SKFP-852)

## Description
Si on resize le browser alors que la grille n'est pas encore chargé, la config peut se corrompe.

## Screenshot
### Before
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/d269f192-1ee7-44bf-a51d-2894d8bd479d

### After
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/aee32319-e131-4c8a-b9eb-86af5762d622

