### PR TITLE
fix(grid): SKFP-852 remove breakpoint, rgl should manage it by himself

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.14.9 2023-11-20
+- fix: SKFP-852 remove breakpoint loading system, let rgl manage it by himself
+
 ### 7.14.8 2023-11-08
 - fix: SKFP-852 prevent the grid to be saved while the grid is still loading
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.8",
+    "version": "7.14.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.14.8",
+            "version": "7.14.9",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.8",
+    "version": "7.14.9",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/ResizableGridLayout/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/index.tsx
@@ -335,7 +335,6 @@ const ResizableGridLayout = ({
     const [isLoaded, setIsLoaded] = useState(false);
     const [isDraggable, setIsDraggable] = useState(false);
     const [isResizable, setIsResizable] = useState(false);
-    const [currentBreakpoint, setCurrentBreakpoint] = useState<string>('md');
     const configs = deserialize(defaultLayouts, layouts);
     const responsiveDefaultLayouts = serializeConfigToLayouts(configs);
     const resizableItemsList = configs.map(({ hidden, id, title }) => ({
@@ -389,12 +388,6 @@ const ResizableGridLayout = ({
                             layouts={responsiveDefaultLayouts}
                             margin={[12, 12]}
                             maxRows={10}
-                            onBreakpointChange={(newBreakpoint: string, newCols: number) => {
-                                if (newBreakpoint === currentBreakpoint) {
-                                    return;
-                                }
-                                setCurrentBreakpoint(newBreakpoint);
-                            }}
                             onLayoutChange={(currentLayout, allLayouts) => {
                                 if (!isLoaded || isLayoutConfigEqual(allLayouts, configs)) {
                                     return;
@@ -410,14 +403,7 @@ const ResizableGridLayout = ({
                                 if (layout.hidden) {
                                     return;
                                 }
-                                return (
-                                    <div
-                                        data-grid={layout[currentBreakpoint as keyof IResizableGridLayoutConfig]}
-                                        key={layout.id}
-                                    >
-                                        {layout.component}
-                                    </div>
-                                );
+                                return <div key={layout.id}>{layout.component}</div>;
                             })}
                         </ResponsiveGridLayout>
                     )}


### PR DESCRIPTION
# FIX 

- closes #[852](https://d3b.atlassian.net/browse/SKFP-852)

## Description
Le système de breakpoint custom n'est plus utile avec les derniers fix. Il causait aussi un problème qui corrompait la config lors d'un premier chargement


## Screenshot
### Before
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/4cb3a242-0db3-4b6b-b729-f89fe3a64f9f

### After
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/690eb9a1-4078-47b5-8ac0-f156a743a89d
