### PR TITLE
fix(grid): SKFP-858 fix mouseover cutoff

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.14.10 2023-11-21
+- fix: SKFP-858 fix mouseover cutoff on resizable grid card
+
 ### 7.14.9 2023-11-20
 - fix: SKFP-852 remove breakpoint loading system, let rgl manage it by himself
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.9",
+    "version": "7.14.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.14.9",
+            "version": "7.14.10",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.9",
+    "version": "7.14.10",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/view/v2/GridCard/Gridcard.module.scss
+++ b/packages/ui/src/view/v2/GridCard/Gridcard.module.scss
@@ -49,6 +49,7 @@ $padding-side-and-bottom: 24px;
       }
       div[class$="-body"] {
         padding: 16px !important;
+        overflow: inherit;
       }
     }
 


### PR DESCRIPTION
# FIX

- closes #[858](https://d3b.atlassian.net/browse/SKFP-858)

## Description
Mouse over is cuttoff on the border of each card

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1a09b7fe-0104-4405-aab9-523a40cd1f0a


### After

https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/2f374efa-91e2-4b9a-85ca-a848fd252c7e


