### PR TITLE
feat: CQDG-490 ProTable tooltip should be ReactNode

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.14.12 2023-11-23
+- fix: CQDG-490 ProTable tooltip should be ReactNode
+
 ### 7.14.10 2023-11-22
 - fix: SKFP-852 fix baby graph issue
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.11",
+    "version": "7.14.12",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -63,7 +63,7 @@ export interface ProColumnType<T = any> extends ColumnType<T> {
     title: ReactNode;
     icon?: ReactElement;
     iconTitle?: ReactNode;
-    tooltip?: string;
+    tooltip?: ReactNode;
     defaultHidden?: boolean;
 }
 


### PR DESCRIPTION
feat: CQDG-490 ProTable tooltip should be ReactNode

- closes #TICKET_NUMBER

## Description

We need to use tooltip in our Table as expected by antd Tooltip title

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

