### PR TITLE
feat: CQDG-490 Add Popover on ProTable title

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.15.0 2023-11-29
+- fix: CQDG-490 Add Popover on ProTable title
+
 ### 7.14.15 2023-11-28
 - fix: SKFP-852 minor update to fix pipeline
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.15",
+    "version": "7.15.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.14.15",
+            "version": "7.15.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.14.15",
+    "version": "7.15.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/index.module.scss
+++ b/packages/ui/src/components/ProTable/index.module.scss
@@ -12,3 +12,7 @@
   font-weight: 500;
   color: $heading-color;
 }
+
+.dotted {
+  border-bottom: 1px dotted;
+}

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { DownloadOutlined } from '@ant-design/icons';
-import { Button, Space, Table, Tooltip } from 'antd';
+import { Button, Popover, Space, Table, Tooltip } from 'antd';
 import cx from 'classnames';
 import { isEmpty } from 'lodash';
 
@@ -203,19 +203,8 @@ const ProTable = <RecordType extends object & { key: string } = any>({
     };
 
     const getTitleByType = (column: ProColumnType) => {
-        const titleToUse = column.iconTitle ? column.iconTitle : column.title;
-        let title = column.tooltip ? (
-            <span
-                style={{
-                    borderBottom: '1px dotted',
-                }}
-            >
-                {titleToUse}
-            </span>
-        ) : (
-            titleToUse
-        );
-
+        const titleToUse = column.iconTitle || column.title;
+        let title = column.tooltip ? <span style={{ borderBottom: '1px dotted' }}>{titleToUse}</span> : titleToUse;
         title =
             column.icon && !column.iconTitle ? (
                 <Space size={3}>
@@ -224,8 +213,8 @@ const ProTable = <RecordType extends object & { key: string } = any>({
             ) : (
                 title
             );
-
         title = column.tooltip ? <Tooltip title={column.tooltip}>{title}</Tooltip> : title;
+        title = column.popoverProps ? <Popover {...column.popoverProps}>{column.title}</Popover> : title;
         return title;
     };
 

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -32,7 +32,11 @@ export const getTitleByType = (column: ProColumnType): React.ReactNode => {
         );
     }
     if (column.popoverProps) {
-        return <Popover {...column.popoverProps}>{titleToUse}</Popover>;
+        return (
+            <Popover className={styles.dotted} {...column.popoverProps}>
+                {titleToUse}
+            </Popover>
+        );
     }
     if (column.tooltip) {
         return (

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -22,6 +22,28 @@ import {
 
 import styles from './index.module.scss';
 
+export const getTitleByType = (column: ProColumnType): React.ReactNode => {
+    let titleToUse = column.iconTitle || column.title;
+    if (column.icon) {
+        titleToUse = (
+            <Space size={3}>
+                {column.icon} {titleToUse}
+            </Space>
+        );
+    }
+    if (column.popoverProps) {
+        return <Popover {...column.popoverProps}>{titleToUse}</Popover>;
+    }
+    if (column.tooltip) {
+        return (
+            <Tooltip className={styles.dotted} title={column.tooltip}>
+                {titleToUse}
+            </Tooltip>
+        );
+    }
+    return titleToUse;
+};
+
 type staticTable = {
     left: TColumnStates;
     dynamic: TColumnStates;
@@ -200,22 +222,6 @@ const ProTable = <RecordType extends object & { key: string } = any>({
         }
 
         return customExtra;
-    };
-
-    const getTitleByType = (column: ProColumnType) => {
-        const titleToUse = column.iconTitle || column.title;
-        let title = column.tooltip ? <span style={{ borderBottom: '1px dotted' }}>{titleToUse}</span> : titleToUse;
-        title =
-            column.icon && !column.iconTitle ? (
-                <Space size={3}>
-                    {column.icon} {title}
-                </Space>
-            ) : (
-                title
-            );
-        title = column.tooltip ? <Tooltip title={column.tooltip}>{title}</Tooltip> : title;
-        title = column.popoverProps ? <Popover {...column.popoverProps}>{column.title}</Popover> : title;
-        return title;
     };
 
     const generateColumnTitle = (column: ProColumnTypes<RecordType>) => {

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode } from 'react';
 import { TableProps } from 'antd';
+import { PopoverProps } from 'antd';
 import { ColumnType, TablePaginationConfig } from 'antd/lib/table';
 
 import { IQueryConfig, ISearchAfter, TQueryConfigCb } from '../../graphql/types';
@@ -60,10 +61,11 @@ export interface IProTableDictionary {
 
 export interface ProColumnType<T = any> extends ColumnType<T> {
     key: string;
-    title: ReactNode;
+    title: string;
     icon?: ReactElement;
     iconTitle?: ReactNode;
     tooltip?: ReactNode;
+    popoverProps?: PopoverProps;
     defaultHidden?: boolean;
 }
 

--- a/packages/ui/src/components/tables/ExpandableTable/index.module.scss
+++ b/packages/ui/src/components/tables/ExpandableTable/index.module.scss
@@ -9,3 +9,7 @@
     text-decoration: none;
   }
 }
+
+.dotted {
+  border-bottom: 1px dotted;
+}

--- a/packages/ui/src/components/tables/ExpandableTable/index.module.scss
+++ b/packages/ui/src/components/tables/ExpandableTable/index.module.scss
@@ -9,7 +9,3 @@
     text-decoration: none;
   }
 }
-
-.dotted {
-  border-bottom: 1px dotted;
-}

--- a/packages/ui/src/components/tables/ExpandableTable/index.tsx
+++ b/packages/ui/src/components/tables/ExpandableTable/index.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement, useState } from 'react';
-import { Popover, Space, Table, Tooltip, Typography } from 'antd';
+import { Table, Typography } from 'antd';
 import { TableProps } from 'antd/lib/table';
 
+import { getTitleByType } from '../../ProTable';
 import { ProColumnType, ProColumnTypes } from '../../ProTable/types';
 
 import styles from './index.module.scss';
@@ -26,30 +27,11 @@ const ExpandableTable = ({
     const sliceNum = showAll ? dataTotalLength : nOfElementsWhenCollapsed;
     const showButton = dataTotalLength > nOfElementsWhenCollapsed;
     const hiddenNum = dataTotalLength - sliceNum;
-
-    const getColumnTitleOrTooltip = (column: ProColumnTypes) => {
-        const titleToUse = column.iconTitle || column.title;
-        let title = column.tooltip ? <span style={{ borderBottom: '1px dotted' }}>{titleToUse}</span> : titleToUse;
-        title =
-            column.icon && !column.iconTitle ? (
-                <Space size={3}>
-                    {column.icon} {title}
-                </Space>
-            ) : (
-                title
-            );
-        title = column.tooltip ? <Tooltip title={column.tooltip}>{title}</Tooltip> : title;
-        title = column.popoverProps ? <Popover {...column.popoverProps}>{column.title}</Popover> : title;
-        return { ...column, title } as ProColumnType;
-    };
+    const columnsWithTitles = columns?.map((column) => ({ ...column, title: getTitleByType(column as ProColumnType) }));
 
     return (
         <>
-            <Table
-                {...tableProps}
-                columns={columns?.map(getColumnTitleOrTooltip)}
-                dataSource={(dataSource || []).slice(0, sliceNum)}
-            />
+            <Table {...tableProps} columns={columnsWithTitles} dataSource={(dataSource || []).slice(0, sliceNum)} />
             {showButton && (
                 <Typography.Link className={styles.fuiExpandableTableBtn} onClick={() => setShowAll(!showAll)}>
                     {buttonText(showAll, hiddenNum)} {showAll ? '-' : '+'}

--- a/packages/ui/src/components/tables/ExpandableTable/index.tsx
+++ b/packages/ui/src/components/tables/ExpandableTable/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Space, Table, Tooltip, Typography } from 'antd';
+import { Popover, Space, Table, Tooltip, Typography } from 'antd';
 import { TableProps } from 'antd/lib/table';
 
 import { ProColumnType, ProColumnTypes } from '../../ProTable/types';
@@ -39,6 +39,7 @@ const ExpandableTable = ({
                 title
             );
         title = column.tooltip ? <Tooltip title={column.tooltip}>{title}</Tooltip> : title;
+        title = column.popoverProps ? <Popover {...column.popoverProps}>{column.title}</Popover> : title;
         return { ...column, title } as ProColumnType;
     };
 

--- a/storybook/stories/Components/Tables/ProTable/ProTable.stories.tsx
+++ b/storybook/stories/Components/Tables/ProTable/ProTable.stories.tsx
@@ -58,6 +58,23 @@ BasicTable.args = {
             dataIndex: "column_four",
             defaultHidden: true,
         },
+        {
+            key: "column_five",
+            title: "Column 5",
+            dataIndex: "column_five",
+            defaultHidden: false,
+            popoverProps: {
+                title: "This is the popover title",
+                content: "This is the popover content",
+            },
+        },
+        {
+            key: "column_six",
+            title: "Column 6",
+            dataIndex: "column_six",
+            defaultHidden: false,
+            tooltip:"This is the tooltip content",
+        },
     ],
     dataSource: [
         {
@@ -83,6 +100,20 @@ BasicTable.args = {
         },
         {
             key: "4",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+        {
+            key: "5",
+            column_one: "test",
+            column_two: "test",
+            column_three: "test",
+            column_four: "test",
+        },
+        {
+            key: "6",
             column_one: "test",
             column_two: "test",
             column_three: "test",


### PR DESCRIPTION
# feat: CQDG-490 Add Popover on ProTable title

- closes #TICKET_NUMBER

## Description

https://ferlab-crsj.atlassian.net/browse/CQDG-490

Exemple d'utilisation:
```
{
    key: 'age_at_recruitment',
    dataIndex: 'age_at_recruitment',
    sorter: { multiple: 1 },
    title: intl.get('entities.participant.age'),
    popoverProps: {
      className: styles.tooltip,
      title: <b>{intl.get('entities.participant.age_at_recruitment')}</b>,
      content: ageCategories.map((category) => (
        <div key={category.key}>
          <b>{category.label}:</b>
          {` ${category.tooltip}`}
          <br />
        </div>
      )),
    },
```

## Screenshot
<img width="1452" alt="image" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/15524246/a89c7892-5729-460a-a84a-7c56b1233f47">
<img width="1896" alt="image" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/15524246/bdefe2bf-411b-4a5b-a453-7f5011f7bfb7">

