### PR TITLE
feat(studies): SKFP-874 export authorized studies widget to ferlab

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 7.18.0 2023-12-14
+- feat: SKFP-874 add authorized studies widget
+
 ### 7.17.0 2023-12-14
 - feat: CLIN-1934 add custom pill
 

--- a/packages/ui/jest.setup.js
+++ b/packages/ui/jest.setup.js
@@ -19,3 +19,12 @@ Object.defineProperty(window, 'matchMedia', {
     })),
     writable: true,
 });
+
+jest.mock(
+    'react-router-dom',
+    () => ({
+        BrowserRouter: ({ children }) => children,
+        Link: ({ children }) => children,
+    }),
+    { virtual: true },
+);

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.17.0",
+    "version": "7.18.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "7.17.0",
+            "version": "7.18.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "7.17.0",
+    "version": "7.18.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.module.scss
+++ b/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.module.scss
@@ -1,0 +1,31 @@
+@import 'theme.template';
+
+.list {
+  .filesCount {
+    font-size: 12px;
+
+    .fileLink {
+      padding: 0;
+      height: unset;
+      font-size: 12px;
+      color: $gray-8;
+    }
+  }
+
+  .dataUseGroups {
+    font-size: 12px;
+    display: block;
+  }
+
+  .itemMeta {
+    margin-bottom: 2px;
+
+    *[class$='-meta-title'] {
+      font-size: 14px;
+    }
+  }
+
+  .progress {
+    width: 50%;
+  }
+}

--- a/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.test.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+import { numberWithCommas } from '../../utils/numberUtils';
+
+import AuthorizedStudiesListItem from './AuthorizedStudiesListItem';
+
+const data = {
+    authorized_controlled_files_count: 9152,
+    study_code: 'STUDY_CODE_1',
+    study_id: 'STUDY_ID_1',
+    title: 'Title 1',
+    total_controlled_files_count: 9152,
+    total_files_count: 9152,
+    total_uncontrolled_files_count: 0,
+    user_acl_in_study: ['xxxxx1.x1', 'xxxxx2.x2'],
+};
+
+const dictionary = {
+    authorization: 'authorization',
+    dataGroups: 'dataGroups',
+    files: 'files',
+    of: 'of',
+};
+
+const queryProps = {
+    fileIndex: 'file-index',
+    participantIndex: 'participant-index',
+    queryBuilderId: 'query-build-id',
+    to: 'route/',
+};
+
+describe('AuthorizedStudiesListItem', () => {
+    test('make sure AuthorizedStudiesListItem render correctly', () => {
+        const props = {
+            data,
+            dictionary,
+            queryProps,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesListItem {...props} />
+            </BrowserRouter>,
+        );
+
+        // text
+        expect(screen.getByText(dictionary.authorization)).toBeTruthy();
+        expect(screen.getByText(dictionary.of)).toBeTruthy();
+        expect(screen.getByText(dictionary.dataGroups)).toBeTruthy();
+        expect(screen.getByText(dictionary.files)).toBeTruthy();
+
+        // computed values
+        expect(
+            screen.queryAllByText(
+                numberWithCommas(data.total_controlled_files_count + data.total_uncontrolled_files_count),
+            ),
+        ).toHaveLength(2);
+        expect(screen.queryAllByText(numberWithCommas(data.total_files_count))).toHaveLength(2);
+        expect(screen.getByText(data.user_acl_in_study.join(', '))).toBeTruthy();
+    });
+});

--- a/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/AuthorizedStudiesListItem.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, List, Progress, Space, Typography } from 'antd';
+import cx from 'classnames';
+
+import { generateQuery, generateValueFilter } from '../../data/sqon/utils';
+import { numberWithCommas } from '../../utils/numberUtils';
+import { addQuery } from '../QueryBuilder/utils/useQueryBuilderState';
+
+import { IAuthorizedStudy } from '.';
+
+import styles from './AuthorizedStudiesListItem.module.scss';
+
+export interface IAuthorizedStudyQueryProps {
+    to: string;
+    queryBuilderId: string;
+    participantIndex: string;
+    fileIndex: string;
+}
+
+export type TAuthorizedStudiesListItemDictionary = {
+    authorization?: string;
+    of?: string;
+    dataGroups?: string;
+    files?: string;
+};
+
+interface IAuthorizedStudiesListItem {
+    data: IAuthorizedStudy;
+    dictionary?: TAuthorizedStudiesListItemDictionary;
+    queryProps: IAuthorizedStudyQueryProps;
+}
+
+const { Text } = Typography;
+
+const AuthorizedStudiesListItem = ({ data, dictionary, queryProps }: IAuthorizedStudiesListItem): JSX.Element => {
+    const computedFilesCount = data.total_controlled_files_count + data.total_uncontrolled_files_count;
+
+    return (
+        <List.Item className={cx('wrapped', styles.list)}>
+            <List.Item.Meta
+                className={styles.itemMeta}
+                description={
+                    <div className={styles.filesCount}>
+                        {dictionary?.authorization ?? 'Authorization : '}
+                        <Space size={4}>
+                            <Link
+                                onClick={() => {
+                                    addQuery({
+                                        query: generateQuery({
+                                            newFilters: [
+                                                generateValueFilter({
+                                                    field: 'study_id',
+                                                    index: queryProps.participantIndex,
+                                                    value: [data.study_id],
+                                                }),
+                                                generateValueFilter({
+                                                    field: 'acl',
+                                                    index: queryProps.fileIndex,
+                                                    value: data.user_acl_in_study,
+                                                }),
+                                            ],
+                                        }),
+                                        queryBuilderId: queryProps.queryBuilderId,
+                                        setAsActive: true,
+                                    });
+                                }}
+                                to={queryProps.to}
+                            >
+                                <Button className={styles.fileLink} type="link">
+                                    <span>{numberWithCommas(computedFilesCount)}</span>
+                                </Button>
+                            </Link>
+                            <span className={styles.of}>{dictionary?.of ?? 'of'}</span>
+                            <Link
+                                onClick={() => {
+                                    addQuery({
+                                        query: generateQuery({
+                                            newFilters: [
+                                                generateValueFilter({
+                                                    field: 'study_id',
+                                                    index: queryProps.participantIndex,
+                                                    value: [data.study_id],
+                                                }),
+                                            ],
+                                        }),
+                                        queryBuilderId: queryProps.queryBuilderId,
+                                        setAsActive: true,
+                                    });
+                                }}
+                                to={queryProps.to}
+                            >
+                                <Button className={styles.fileLink} type="link">
+                                    <span>{numberWithCommas(data.total_files_count)}</span>
+                                </Button>
+                            </Link>
+                            <span>{dictionary?.files ?? 'Files'}</span>
+                        </Space>
+                    </div>
+                }
+                title={
+                    <Text ellipsis title={data.title}>
+                        {data.title}
+                    </Text>
+                }
+            />
+            <Text className={styles.dataUseGroups} type="secondary">
+                <Space size={4}>
+                    <span>{dictionary?.dataGroups || 'Data use groups:'}</span>
+                    <span>{data.user_acl_in_study.join(', ')}</span>
+                </Space>
+            </Text>
+            <Progress
+                className={styles.progress}
+                percent={Math.round((computedFilesCount / data.total_files_count) * 100)}
+                size="small"
+            ></Progress>
+        </List.Item>
+    );
+};
+
+export default AuthorizedStudiesListItem;

--- a/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.module.scss
+++ b/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.module.scss
@@ -1,0 +1,19 @@
+@import 'theme.template';
+
+.item {
+  padding: 16px;
+  background-color: $gray-2;
+  margin-top: 24px;
+
+  .alert {
+    align-items: baseline;
+    margin-top: 16px;
+    width: 100%;
+  }
+
+  .switch {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.test.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { MinusCircleFilled, PlusCircleFilled } from '@ant-design/icons';
+import { render, screen } from '@testing-library/react';
+
+import FencesAuthentificationModal from './FencesAuthentificationModal';
+import { FENCE_AUHTENTIFICATION_STATUS, IFenceService } from '.';
+
+const services: IFenceService[] = [
+    {
+        fence: 'fence1',
+        icon: <PlusCircleFilled height={45} width={45} />,
+        name: 'Fence 1',
+        onConnectToFence: () => jest.fn(),
+        onDisconnectFromFence: () => jest.fn(),
+    },
+    {
+        fence: 'fence2',
+        icon: <MinusCircleFilled height={45} width={45} />,
+        name: 'Fence 2',
+        onConnectToFence: () => jest.fn(),
+        onDisconnectFromFence: () => jest.fn(),
+    },
+];
+
+const dictionary = {
+    close: 'close',
+    description: 'description',
+    error: 'error',
+    title: 'title',
+};
+
+describe('FencesAuthentificationModal', () => {
+    test('make sure FencesAuthentificationModal render correctly when closed', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+            ],
+            onCancel: jest.fn(),
+            open: false,
+            services,
+        };
+
+        render(<FencesAuthentificationModal {...props} />);
+        expect(screen.queryAllByText(dictionary.title)).toHaveLength(0);
+        expect(screen.queryAllByText(dictionary.description)).toHaveLength(0);
+        expect(screen.queryAllByText(dictionary.close)).toHaveLength(0);
+    });
+
+    test('make sure FencesAuthentificationModal render correctly with connected fences', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+            ],
+            onCancel: jest.fn(),
+            open: true,
+            services,
+        };
+
+        render(<FencesAuthentificationModal {...props} />);
+        expect(screen.getByText(dictionary.title)).toBeTruthy();
+        expect(screen.getByText(dictionary.description)).toBeTruthy();
+        expect(screen.getByText(dictionary.close)).toBeTruthy();
+
+        expect(screen.queryAllByRole('switch', { checked: true })).toHaveLength(2);
+        expect(screen.queryAllByRole('switch', { checked: false })).toHaveLength(0);
+    });
+    test('make sure FencesAuthentificationModal render correctly with disconnected fences', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+            ],
+            onCancel: jest.fn(),
+            open: true,
+            services,
+        };
+
+        render(<FencesAuthentificationModal {...props} />);
+        expect(screen.getByText(dictionary.title)).toBeTruthy();
+        expect(screen.getByText(dictionary.description)).toBeTruthy();
+        expect(screen.getByText(dictionary.close)).toBeTruthy();
+
+        expect(screen.queryAllByRole('switch', { checked: true })).toHaveLength(0);
+        expect(screen.queryAllByRole('switch', { checked: false })).toHaveLength(2);
+    });
+
+    test('make sure FencesAuthentificationModal render correctly with connected and disconnected fences', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+            ],
+            onCancel: jest.fn(),
+            open: true,
+            services,
+        };
+
+        render(<FencesAuthentificationModal {...props} />);
+        expect(screen.getByText(dictionary.title)).toBeTruthy();
+        expect(screen.getByText(dictionary.description)).toBeTruthy();
+        expect(screen.getByText(dictionary.close)).toBeTruthy();
+
+        expect(screen.queryAllByRole('switch', { checked: true })).toHaveLength(1);
+        expect(screen.queryAllByRole('switch', { checked: false })).toHaveLength(1);
+    });
+
+    test('make sure FencesAuthentificationModal render correctly with errors in fences', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: true,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+            ],
+            onCancel: jest.fn(),
+            open: true,
+            services,
+        };
+
+        render(<FencesAuthentificationModal {...props} />);
+        expect(screen.getByText(dictionary.title)).toBeTruthy();
+        expect(screen.getByText(dictionary.description)).toBeTruthy();
+        expect(screen.getByText(dictionary.close)).toBeTruthy();
+        expect(screen.getByText(dictionary.error)).toBeTruthy();
+
+        expect(screen.queryAllByRole('switch', { checked: true })).toHaveLength(0);
+        expect(screen.queryAllByRole('switch', { checked: false })).toHaveLength(2);
+    });
+});

--- a/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/FencesAuthentificationModal.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Alert, Button, Switch } from 'antd';
+import Modal, { ModalFuncProps } from 'antd/lib/modal/Modal';
+
+import { FENCE_AUHTENTIFICATION_STATUS, IFence, IFenceService } from '.';
+
+import styles from './FencesAuthentificationModal.module.scss';
+
+export type TFencesAuthentificationModalDictionary = {
+    title?: string;
+    close?: string;
+    description?: string;
+    error?: string;
+};
+
+interface IFencesAuthentificationModal extends ModalFuncProps {
+    fences: IFence[];
+    services: IFenceService[];
+    dictionary?: TFencesAuthentificationModalDictionary;
+}
+
+const FencesAuthentificationModal = ({
+    dictionary,
+    fences,
+    onCancel,
+    services,
+    ...rest
+}: IFencesAuthentificationModal): JSX.Element => (
+    <Modal
+        footer={[
+            <Button key="close" onClick={onCancel} type="primary">
+                {dictionary?.close ?? 'close'}
+            </Button>,
+        ]}
+        onCancel={onCancel}
+        title={dictionary?.title ?? 'Manage Connections'}
+        {...rest}
+    >
+        <>
+            <p>
+                {dictionary?.description ??
+                    'Access select NCI and Kids First controlled access data by connecting your account using your NIH login credentials. Please remember that it is your responsibility to follow any data use limitations with controlled access data.'}
+            </p>
+            <>
+                {services.map(({ fence, icon, name, onConnectToFence, onDisconnectFromFence }) => {
+                    const fenceInfo = fences.find((f) => f.id === fence);
+
+                    if (!fenceInfo) {
+                        return;
+                    }
+
+                    return (
+                        <div className={styles.item} key={fenceInfo.id}>
+                            <div className={styles.switch}>
+                                {icon}
+                                <span>{name}</span>
+                                <Switch
+                                    checked={fenceInfo.status === FENCE_AUHTENTIFICATION_STATUS.connected}
+                                    loading={fenceInfo.loading}
+                                    onClick={() => {
+                                        if (fenceInfo.status === FENCE_AUHTENTIFICATION_STATUS.connected) {
+                                            onDisconnectFromFence();
+                                            return;
+                                        }
+                                        onConnectToFence();
+                                    }}
+                                />
+                            </div>
+                            {fenceInfo.error && (
+                                <Alert
+                                    className={styles.alert}
+                                    closable
+                                    message={
+                                        dictionary?.error ??
+                                        'We were unable to establish a connection. Please try again later.'
+                                    }
+                                    type="error"
+                                />
+                            )}
+                        </div>
+                    );
+                })}
+            </>
+        </>
+    </Modal>
+);
+
+export default FencesAuthentificationModal;

--- a/packages/ui/src/components/AuthorizedStudies/index.module.scss
+++ b/packages/ui/src/components/AuthorizedStudies/index.module.scss
@@ -1,0 +1,70 @@
+@import "theme.template";
+
+.authenticatedHeader {
+  margin-bottom: $authorized-studies-widget-authenticated-header-margin-bottom;
+  height: $authorized-studies-widget-authenticated-header-height;
+
+  .disconnectBtn {
+    padding: 0;
+    font-size: 12px;
+  }
+
+  .notice {
+    font-size: 12px;
+    line-height: 10px;
+  }
+}
+
+.content {
+  border: 1px solid $gray-4;
+  background: $gray-1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.connected {
+  height: calc(100% - ($authorized-studies-widget-authenticated-header-height + $authorized-studies-widget-authenticated-header-margin-bottom));
+}
+
+.list {
+  overflow: auto;
+  min-height: 200px;
+  height: 100%;
+}
+
+.cardHeader {
+  width: 100%;
+
+  .titleContainer {
+    min-width: 200px;
+  }
+
+  .dragHandle {
+    font-size: 16px;
+    color: $gray-7;
+    outline: none;
+  }
+
+  .infoIcon {
+    color: $body-2;
+    font-size: 18px;
+  }
+
+  .infoPopoverOverlay {
+    max-width: 350px;
+  }
+}
+
+.infoPopover {
+  margin-left: 5px;
+
+  .infoPopoverContent {
+    border: none;
+    background: $gray-1;
+  }
+}
+
+.popoverExternalLink {
+  margin-left: 4px !important;
+}

--- a/packages/ui/src/components/AuthorizedStudies/index.test.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/index.test.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { MinusCircleFilled, PlusCircleFilled } from '@ant-design/icons';
+import { render, screen } from '@testing-library/react';
+
+import AuthorizedStudiesWidget, { FENCE_AUHTENTIFICATION_STATUS, IFenceService } from '.';
+
+const authorizedStudies = {
+    error: false,
+    loading: false,
+    studies: [
+        {
+            authorized_controlled_files_count: 9152,
+            study_code: 'STUDY_CODE_1',
+            study_id: 'STUDY_ID_1',
+            title: 'Title 1',
+            total_controlled_files_count: 9152,
+            total_files_count: 9152,
+            total_uncontrolled_files_count: 0,
+            user_acl_in_study: ['xxxxx1.x1', 'xxxxx2.x2'],
+        },
+        {
+            authorized_controlled_files_count: 682,
+            study_code: 'STUDY_CODE_2',
+            study_id: 'STUDY_ID_2',
+            title: 'Title 2',
+            total_controlled_files_count: 12679,
+            total_files_count: 16735,
+            total_uncontrolled_files_count: 4056,
+            user_acl_in_study: ['xxxxx3.x3'],
+        },
+    ],
+};
+
+const services: IFenceService[] = [
+    {
+        fence: 'fence1',
+        icon: <PlusCircleFilled height={45} width={45} />,
+        name: 'Fence 1',
+        onConnectToFence: () => jest.fn(),
+        onDisconnectFromFence: () => jest.fn(),
+    },
+    {
+        fence: 'fence2',
+        icon: <MinusCircleFilled height={45} width={45} />,
+        name: 'Fence 2',
+        onConnectToFence: () => jest.fn(),
+        onDisconnectFromFence: () => jest.fn(),
+    },
+];
+
+const queryProps = {
+    fileIndex: 'file-index',
+    participantIndex: 'participant-index',
+    queryBuilderId: 'query-build-id',
+    to: 'route/',
+};
+
+const dictionary = {
+    authentification: {
+        action: 'authentification.action',
+        description: 'authentification.description',
+    },
+    connectedNotice: 'connectedNotice',
+    error: {
+        contactSupport: 'error.contactSupport',
+        email: 'error.email',
+        subtitle: 'error.subtitle',
+        title: 'error.title',
+    },
+    list: {
+        authorization: 'list.authorization',
+        dataGroups: 'list.dataGroups',
+        files: 'list.files',
+        of: 'list.of',
+    },
+    manageConnections: 'manageConnections',
+    noAvailableStudies: 'noAvailableStudies',
+};
+
+describe('AuthorizedStudiesWidget', () => {
+    test('make sure AuthorizedStudiesWidget can render the connect content if fence status are unknow', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                },
+            ],
+            id: '1',
+            queryProps,
+            services,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesWidget {...props} />
+            </BrowserRouter>,
+        );
+        expect(screen.getByText(dictionary.authentification.action)).toBeTruthy();
+        expect(screen.getByText(dictionary.authentification.description)).toBeTruthy();
+    });
+
+    test('make sure AuthorizedStudiesWidget can render the connect content if fence status are disconnected', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                },
+            ],
+            id: '1',
+            queryProps,
+            services,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesWidget {...props} />
+            </BrowserRouter>,
+        );
+        expect(screen.getByText(dictionary.authentification.action)).toBeTruthy();
+        expect(screen.getByText(dictionary.authentification.description)).toBeTruthy();
+    });
+
+    test('make sure AuthorizedStudiesWidget can render a list of authorized studies', () => {
+        const props = {
+            authorizedStudies,
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+                {
+                    acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+            ],
+            id: '1',
+            queryProps,
+            services,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesWidget {...props} />
+            </BrowserRouter>,
+        );
+        expect(screen.getByText(dictionary.manageConnections)).toBeTruthy();
+        expect(screen.getByText(dictionary.connectedNotice)).toBeTruthy();
+        expect(screen.queryAllByText(dictionary.list.authorization)).toHaveLength(2);
+        expect(screen.queryAllByText(dictionary.list.of)).toHaveLength(2);
+        expect(screen.queryAllByText(dictionary.list.files)).toHaveLength(2);
+        expect(screen.queryAllByText(dictionary.list.dataGroups)).toHaveLength(2);
+    });
+
+    test('make sure AuthorizedStudiesWidget can render an empty list of authorized studies', () => {
+        const props = {
+            authorizedStudies: {
+                error: false,
+                loading: false,
+                studies: [],
+            },
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: false,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+                {
+                    acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                    error: false,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                },
+            ],
+            id: '1',
+            queryProps,
+            services,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesWidget {...props} />
+            </BrowserRouter>,
+        );
+        expect(screen.getByText(dictionary.manageConnections)).toBeTruthy();
+        expect(screen.getByText(dictionary.noAvailableStudies)).toBeTruthy();
+    });
+
+    test('make sure AuthorizedStudiesWidget can render an error message', () => {
+        const props = {
+            dictionary,
+            fences: [
+                {
+                    acl: [],
+                    error: true,
+                    id: 'fence1',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.disconnected,
+                },
+                {
+                    acl: [],
+                    error: true,
+                    id: 'fence2',
+                    loading: false,
+                    status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                },
+            ],
+            id: '1',
+            queryProps,
+            services,
+        };
+
+        render(
+            <BrowserRouter>
+                <AuthorizedStudiesWidget {...props} />
+            </BrowserRouter>,
+        );
+        expect(screen.getByText(dictionary.error.title)).toBeTruthy();
+        expect(screen.getByText(dictionary.error.subtitle, { exact: false })).toBeTruthy();
+        expect(screen.getByText(dictionary.error.contactSupport)).toBeTruthy();
+    });
+});

--- a/packages/ui/src/components/AuthorizedStudies/index.tsx
+++ b/packages/ui/src/components/AuthorizedStudies/index.tsx
@@ -1,0 +1,248 @@
+import React, { useState } from 'react';
+import { ApiOutlined, SafetyOutlined } from '@ant-design/icons';
+import { Button, List, Result, Space } from 'antd';
+import Text from 'antd/lib/typography/Text';
+import cx from 'classnames';
+
+import GridCard, { GridCardHeader } from '../../view/v2/GridCard';
+import CardConnectPlaceholder, {
+    TCardConnectPlaceholderDictionary,
+} from '../../view/v2/GridCard/GridCardConnectPlaceholder';
+import Empty from '../Empty';
+import ExternalLink from '../ExternalLink';
+import PopoverContentLink from '../PopoverContentLink';
+
+import AuthorizedStudiesListItem, {
+    IAuthorizedStudyQueryProps,
+    TAuthorizedStudiesListItemDictionary,
+} from './AuthorizedStudiesListItem';
+import FencesAuthentificationModal, { TFencesAuthentificationModalDictionary } from './FencesAuthentificationModal';
+
+import styles from './index.module.scss';
+
+enum WIDGET_STATE {
+    error = 'error',
+    connected = 'connected',
+    disconnected = 'disconnected',
+}
+
+export enum FENCE_AUHTENTIFICATION_STATUS {
+    connected = 'connected',
+    disconnected = 'disconnected',
+    unknown = 'unknown',
+}
+
+export interface IAuthorizedStudy {
+    user_acl_in_study: string[];
+    title: string;
+    total_uncontrolled_files_count: number;
+    total_controlled_files_count: number;
+    total_files_count: number;
+    study_id: string;
+}
+
+export interface IAuthorizedStudies {
+    studies: IAuthorizedStudy[];
+    error: boolean;
+    loading: boolean;
+}
+
+export interface IFence {
+    id: string;
+    status: FENCE_AUHTENTIFICATION_STATUS;
+    loading: boolean;
+    acl: string[];
+    error: boolean;
+}
+
+export interface IFenceService {
+    fence: string;
+    name: React.ReactNode | string;
+    icon: React.ReactNode;
+    onConnectToFence: () => void;
+    onDisconnectFromFence: () => void;
+}
+
+interface IAuthorizedStudiesWidget {
+    id: string;
+    className?: string;
+    fences: IFence[];
+    services: IFenceService[];
+    authorizedStudies?: IAuthorizedStudies;
+    queryProps: IAuthorizedStudyQueryProps;
+    dictionary?: {
+        title?: string;
+        connectedNotice?: string;
+        disconnectedNotice?: string;
+        manageConnections?: string;
+        noAvailableStudies?: string;
+        authentification?: TCardConnectPlaceholderDictionary;
+        list?: TAuthorizedStudiesListItemDictionary;
+        error?: {
+            title?: string;
+            subtitle?: string;
+            contactSupport?: string;
+            email?: string;
+        };
+        popover?: {
+            title?: string;
+            applyingForDataAccess?: string;
+            content?: string;
+        };
+        modal?: TFencesAuthentificationModalDictionary;
+    };
+}
+
+const AuthorizedStudiesWidget = ({
+    authorizedStudies,
+    className = '',
+    dictionary,
+    fences,
+    id,
+    queryProps,
+    services,
+}: IAuthorizedStudiesWidget): JSX.Element => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    let state = WIDGET_STATE.disconnected;
+
+    // check if has one fence connected
+    if (fences.some((fence) => fence.status === FENCE_AUHTENTIFICATION_STATUS.connected)) {
+        state = WIDGET_STATE.connected;
+    }
+
+    if (fences.some((fence) => fence.error)) {
+        state = WIDGET_STATE.error;
+    }
+
+    return (
+        <>
+            <FencesAuthentificationModal
+                dictionary={dictionary?.modal}
+                fences={fences}
+                onCancel={() => setIsModalOpen(false)}
+                open={isModalOpen}
+                services={services}
+            />
+            <GridCard
+                content={
+                    <>
+                        {/* Error */}
+                        {state === WIDGET_STATE.error && (
+                            <div className={styles.content}>
+                                <Result
+                                    status="error"
+                                    subTitle={
+                                        <Text>
+                                            {dictionary?.error?.subtitle}
+                                            <ExternalLink href={`mailto:${dictionary?.error?.email}`}>
+                                                <Text>{dictionary?.error?.contactSupport}</Text>
+                                            </ExternalLink>
+                                            .
+                                        </Text>
+                                    }
+                                    title={dictionary?.error?.title}
+                                />
+                            </div>
+                        )}
+
+                        {/* Connect Card  */}
+                        {state === WIDGET_STATE.disconnected && (
+                            <div className={styles.content}>
+                                <CardConnectPlaceholder
+                                    btnProps={{
+                                        onClick: () => setIsModalOpen(true),
+                                    }}
+                                    dictionary={dictionary?.authentification}
+                                />
+                            </div>
+                        )}
+
+                        {/* List of Authorized Studies */}
+                        {state === WIDGET_STATE.connected && (
+                            <div className={styles.connected}>
+                                <div className={styles.authenticatedHeader}>
+                                    <Space align="start">
+                                        <SafetyOutlined className={styles.safetyIcon} />
+                                        <Text className={styles.notice}>
+                                            {dictionary?.connectedNotice ??
+                                                'You have access to the following controlled data. '}
+                                            <Button
+                                                className={styles.disconnectBtn}
+                                                danger
+                                                icon={<ApiOutlined />}
+                                                loading={authorizedStudies?.loading}
+                                                onClick={() => setIsModalOpen(true)}
+                                                size="small"
+                                                type="link"
+                                            >
+                                                {dictionary?.manageConnections ?? 'Manage your connections'}
+                                            </Button>
+                                        </Text>
+                                    </Space>
+                                </div>
+                                <List<IAuthorizedStudy>
+                                    bordered
+                                    className={styles.list}
+                                    dataSource={authorizedStudies?.studies ?? []}
+                                    itemLayout="vertical"
+                                    loading={authorizedStudies?.loading}
+                                    locale={{
+                                        emptyText: (
+                                            <Empty
+                                                description={dictionary?.noAvailableStudies ?? 'No available studies'}
+                                                imageType="grid"
+                                            />
+                                        ),
+                                    }}
+                                    renderItem={(item) => (
+                                        <AuthorizedStudiesListItem
+                                            data={item}
+                                            dictionary={dictionary?.list}
+                                            key={item.study_id}
+                                            queryProps={queryProps}
+                                        />
+                                    )}
+                                />
+                            </div>
+                        )}
+                    </>
+                }
+                theme="shade"
+                title={
+                    <GridCardHeader
+                        className={styles.cardHeader}
+                        handleClassName={styles.dragHandle}
+                        id={id}
+                        infoPopover={{
+                            className: styles.infoPopover,
+                            content: (
+                                <Space className={styles.infoPopoverContent} direction="vertical" size={0}>
+                                    <Text>
+                                        {dictionary?.popover?.content ??
+                                            'Users requesting access to controlled data are required to have an eRA Commons account. Read more on'}
+                                        <PopoverContentLink
+                                            className={styles.popoverExternalLink}
+                                            externalHref="https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?login=&page=login"
+                                            title={
+                                                dictionary?.popover?.applyingForDataAccess || 'applying for data access'
+                                            }
+                                        />
+                                        .
+                                    </Text>
+                                </Space>
+                            ),
+                            iconClassName: styles.infoIcon,
+                            title: dictionary?.popover?.title ?? 'Accessing Data',
+                        }}
+                        title={dictionary?.title ?? 'Authorized Studies'}
+                        withHandle
+                    />
+                }
+                wrapperClassName={cx(styles.wrapper, className)}
+            />
+        </>
+    );
+};
+
+export default AuthorizedStudiesWidget;

--- a/packages/ui/src/components/ExternalLink/index.tsx
+++ b/packages/ui/src/components/ExternalLink/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Space } from 'antd';
-import cx from 'classnames';
 
 import ExternalLinkIcon from './ExternalLinkIcon';
 
@@ -15,7 +14,7 @@ export type IExternalLinkProps = Omit<
 >;
 
 const ExternalLink = (props: IExternalLinkProps) => (
-    <a {...props} className={props.className} rel="noreferrer" target="_blank">
+    <a rel="noreferrer" target="_blank" {...props}>
         <Space size={5.75}>
             <div className={styles.fuiExternalLink}>{props.children}</div>
             {props.hasIcon && <ExternalLinkIcon height="14" width="14" />}

--- a/packages/ui/src/components/PopoverContentLink/index.module.scss
+++ b/packages/ui/src/components/PopoverContentLink/index.module.scss
@@ -1,0 +1,8 @@
+@import 'theme.template';
+
+.popoverContentLink {
+  padding: 0;
+  &:hover {
+    color: $body-1;
+  }
+}

--- a/packages/ui/src/components/PopoverContentLink/index.tsx
+++ b/packages/ui/src/components/PopoverContentLink/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { Button, ButtonProps } from 'antd';
+
+import ExternalLink from '../ExternalLink';
+
+import styles from './index.module.scss';
+
+type TPopoverContentLink = Omit<LinkProps, 'to'> & {
+    title: string;
+    externalHref?: string;
+    to?: any;
+};
+
+const buttonProps: ButtonProps = {
+    className: styles.popoverContentLink,
+    size: 'small',
+    type: 'link',
+};
+
+const PopoverContentLink = ({ externalHref, title, to, ...linkProps }: TPopoverContentLink): JSX.Element => {
+    if (externalHref) {
+        return (
+            <ExternalLink href={externalHref} {...linkProps}>
+                <Button {...buttonProps}>{title}</Button>
+            </ExternalLink>
+        );
+    }
+
+    return (
+        <Link to={to} {...linkProps}>
+            <Button {...buttonProps}>{title}</Button>
+        </Link>
+    );
+};
+
+export default PopoverContentLink;

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.module.scss
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.module.scss
@@ -4,6 +4,10 @@
   height: 100%;
   width: 100%;
 
+  .cardHeader {
+    font-size: 12px;
+  }
+
   .extra {
     display: flex;
     padding-right: 8px;

--- a/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
+++ b/packages/ui/src/layout/ResizableGridLayout/ResizableGridCard/index.tsx
@@ -249,6 +249,7 @@ const ResizableGridCard = ({
                 resizable
                 title={
                     <GridCardHeader
+                        className={styles.cardHeader}
                         extra={extra}
                         extraClassName={styles.extra}
                         id={headerTitle}

--- a/packages/ui/src/utils/numberUtils.ts
+++ b/packages/ui/src/utils/numberUtils.ts
@@ -45,7 +45,7 @@ export const numberFormat = (num: number, digits = 0) => {
     }
 };
 
-export const numberWithCommas = (number: number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+export const numberWithCommas = (number: number) => number?.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
 export const toExponentialNotation = (numberCandidate?: number, fractionDigits = 2): string =>
     numberCandidate ? numberCandidate.toExponential(fractionDigits) : '';

--- a/packages/ui/src/view/v2/GridCard/GridCardConnectPlaceholder.module.scss
+++ b/packages/ui/src/view/v2/GridCard/GridCardConnectPlaceholder.module.scss
@@ -1,0 +1,27 @@
+@import 'theme.template';
+
+.connectPlaceholder {
+  padding: 50px 0;
+  height: 100%;
+  justify-content: center;
+  text-align: center;
+
+  .safetyIcon {
+    font-size: 40px;
+  }
+
+  .iconWrapper {
+    background-color: $gray-5;
+    border-radius: 50px;
+    color: $gray-1;
+    max-width: 64px;
+    height: 64px;
+    justify-content: center;
+    margin: auto;
+    align-items: center;
+    display: flex;
+  }
+  .description {
+    font-size: 12px;
+  }
+}

--- a/packages/ui/src/view/v2/GridCard/GridCardConnectPlaceholder.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCardConnectPlaceholder.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ApiOutlined, SafetyOutlined } from '@ant-design/icons';
+import { Button, ButtonProps, Space, Typography } from 'antd';
+
+import styles from './GridCardConnectPlaceholder.module.scss';
+
+export type TCardConnectPlaceholderDictionary = {
+    description?: string;
+    action?: string;
+};
+
+interface ICardConnectPlaceholder {
+    dictionary?: TCardConnectPlaceholderDictionary;
+    btnProps?: ButtonProps;
+}
+
+const { Text } = Typography;
+
+const CardConnectPlaceholder = ({ btnProps, dictionary }: ICardConnectPlaceholder): JSX.Element => (
+    <Space className={styles.connectPlaceholder} direction="vertical" size={16}>
+        <div>
+            <div className={styles.iconWrapper}>
+                <SafetyOutlined className={styles.safetyIcon} />
+            </div>
+        </div>
+        <Text className={styles.description}>
+            {dictionary?.description ??
+                'To access controlled study files, connect to our data repository partners using your NIH credentials.'}
+        </Text>
+        <Button
+            icon={btnProps?.icon || <ApiOutlined />}
+            size={btnProps?.size || 'small'}
+            type={btnProps?.type || 'primary'}
+            {...btnProps}
+        >
+            {dictionary?.action ?? 'Connect'}
+        </Button>
+    </Space>
+);
+
+export default CardConnectPlaceholder;

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardConnectPlaceholder.test.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardConnectPlaceholder.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import GridCardConnectPlaceholder from '../GridCardConnectPlaceholder';
+
+const dictionary = {
+    action: 'action',
+    description: 'description',
+};
+
+describe('GridCardConnectPlaceholder', () => {
+    test('make sure GridCardConnectPlaceholder render correctly', () => {
+        const props = {
+            dictionary,
+        };
+
+        render(<GridCardConnectPlaceholder {...props} />);
+        expect(screen.getByText(dictionary.description)).toBeTruthy();
+        expect(screen.getByText(dictionary.action)).toBeTruthy();
+    });
+});

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardHeader.module.scss
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/GridCardHeader.module.scss
@@ -2,7 +2,6 @@
 
 .cardHeader {
   display: flex;
-  font-size: 12px !important;
   width: 100%;
 
   div[class$="rgl-drag-zone"] {

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
@@ -2,16 +2,23 @@ import { MutableRefObject, ReactNode, useLayoutEffect, useRef, useState } from '
 import React from 'react';
 import { HolderOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { Popover, PopoverProps, Space, Tooltip, Typography } from 'antd';
+import classnames from 'classnames';
 import cx from 'classnames';
 
 import DragHandle from '../../../../layout/SortableGrid/DragHandle';
 
 import styles from './GridCardHeader.module.scss';
 
+interface IInfoPopover extends PopoverProps {
+    iconClassName?: string;
+}
+
 interface OwnProps {
     id: string;
     title: string;
-    infoPopover?: PopoverProps;
+    infoPopover?: IInfoPopover;
+    className?: string;
+    handleClassName?: string;
     extraClassName?: string;
     extra?: ReactNode[];
     withHandle?: boolean;
@@ -23,6 +30,8 @@ const { Title } = Typography;
 const GridCardHeader = ({
     id,
     title,
+    className,
+    handleClassName,
     extraClassName = '',
     extra = [],
     withHandle = false,
@@ -49,11 +58,11 @@ const GridCardHeader = ({
     }
 
     return (
-        <Title className={styles.cardHeader} level={4} ref={headerContainerRef}>
+        <Title className={classnames(styles.cardHeader, className)} level={4} ref={headerContainerRef}>
             <div className="rgl-drag-zone">
                 <Space align="center" className={styles.cardHeadererContent} direction="horizontal" size={5}>
                     {withHandle && (
-                        <DragHandle className={styles.dragHandle} id={id}>
+                        <DragHandle className={classnames(styles.dragHandle, handleClassName)} id={id}>
                             <HolderOutlined />
                         </DragHandle>
                     )}
@@ -61,7 +70,7 @@ const GridCardHeader = ({
                         <div className={styles.titleContainer} style={{ width: titleWidth }}>
                             <Tooltip title={truncated ? title : undefined}>
                                 <Typography.Text
-                                    ellipsis={{ onEllipsis: setTruncated }}
+                                    ellipsis={titleTruncateThresholdWidth ? { onEllipsis: setTruncated } : {}}
                                     style={{ width: titleWidth }}
                                     tabIndex={0}
                                 >
@@ -76,7 +85,7 @@ const GridCardHeader = ({
                             className={cx(styles.infoPopover, infoPopover.className)}
                             overlayClassName={cx(styles.infoPopoverOverlay, infoPopover.overlayClassName)}
                         >
-                            <InfoCircleOutlined className={styles.infoIcon} />
+                            <InfoCircleOutlined className={classnames(styles.infoIcon, infoPopover.iconClassName)} />
                         </Popover>
                     )}
                 </Space>

--- a/packages/ui/themes/default/_theme.template.scss
+++ b/packages/ui/themes/default/_theme.template.scss
@@ -84,6 +84,10 @@ $multi-label-stack-icon-space: 1.6rem;
 
 $multi-label-stack-top-icon-space: 1rem;
 
+// widget
+$authorized-studies-widget-authenticated-header-height: 24px;
+$authorized-studies-widget-authenticated-header-margin-bottom: 8px;
+
 // Filters
 $toggle-filter-sc-button-color: #008fc7;
 $range-filter-grouped-inputs-spacer-color: #b5c6d8;

--- a/storybook/stories/Components/AuthorizedStudies/AuthorizedStudies.stories.tsx
+++ b/storybook/stories/Components/AuthorizedStudies/AuthorizedStudies.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { Meta } from "@storybook/react/types-6-0";
+
+import { MinusCircleFilled, PlusCircleFilled } from '@ant-design/icons';
+import AuthorizedStudiesWidget, {FENCE_AUHTENTIFICATION_STATUS} from '@ferlab/ui/components/AuthorizedStudies';
+
+const authorizedStudies = {
+    error: false,
+    loading: false,
+    studies: [
+        {
+            authorized_controlled_files_count: 9152,
+            study_code: 'STUDY_CODE_1',
+            study_id: 'STUDY_ID_1',
+            title: 'Title 1',
+            total_controlled_files_count: 9152,
+            total_files_count: 9152,
+            total_uncontrolled_files_count: 0,
+            user_acl_in_study: ['xxxxx1.x1', 'xxxxx2.x2'],
+        },
+        {
+            authorized_controlled_files_count: 682,
+            study_code: 'STUDY_CODE_2',
+            study_id: 'STUDY_ID_2',
+            title: 'Title 2',
+            total_controlled_files_count: 12679,
+            total_files_count: 16735,
+            total_uncontrolled_files_count: 4056,
+            user_acl_in_study: ['xxxxx3.x3'],
+        },
+    ],
+};
+
+const services = [
+    {
+        fence: 'fence1',
+        icon: <PlusCircleFilled height={45} width={45} />,
+        name: 'Fence 1',
+        onConnectToFence: () => {},
+        onDisconnectFromFence: () => {},
+    },
+    {
+        fence: 'fence2',
+        icon: <MinusCircleFilled height={45} width={45} />,
+        name: 'Fence 2',
+        onConnectToFence: () => {},
+        onDisconnectFromFence: () => {},
+    },
+];
+const queryProps = {
+    fileIndex: 'file-index',
+    participantIndex: 'participant-index',
+    queryBuilderId: 'query-build-id',
+    to: 'route/',
+};
+
+
+
+export default {
+    title: "@ferlab/Components/AuthorizedStudies",
+    component: AuthorizedStudiesWidget,
+    decorators: [
+        (Story) => (
+            <>
+                <h2>{Story}</h2>
+                <Story />
+            </>
+        ),
+    ],
+} as Meta;
+
+export const AuthorizedStudiesBasicStory = () => (
+    <>
+        <h2>AuthorizedStudies with disconnected fences</h2>
+        <div style={{width: '400px' }}>
+                <AuthorizedStudiesWidget 
+                id={'1'} 
+                authorizedStudies={{
+                    loading: false,
+                    error: false,
+                    studies: []
+                }}
+                services={services}
+                queryProps={queryProps}
+                fences={[
+                    {
+                        acl: [],
+                        error: false,
+                        id: 'fence1',
+                        loading: false,
+                        status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                    },
+                    {
+                        acl: [],
+                        error: false,
+                        id: 'fence2',
+                        loading: false,
+                        status: FENCE_AUHTENTIFICATION_STATUS.unknown,
+                    },
+                ]}
+                />
+        </div>
+    </>
+);
+
+// React-router is broken with our current version, wait for new storybook to uncomment
+// export const AuthorizedStudiesWithStudiesStory = () => (
+//     <>
+//         <h2>AuthorizedStudies With Connected Fences</h2>
+//         <div style={{width: '400px' }}>
+//             <AuthorizedStudiesWidget 
+//               id={'1'}
+//               authorizedStudies={authorizedStudies}
+//               services={services}
+//               queryProps={queryProps}
+//               fences= {[
+//                   {
+//                       acl: [],
+//                       error: false,
+//                       id: 'fence1',
+//                       loading: false,
+//                       status: FENCE_AUHTENTIFICATION_STATUS.connected,
+//                   },
+//                   {
+//                       acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+//                       error: false,
+//                       id: 'fence2',
+//                       loading: false,
+//                       status: FENCE_AUHTENTIFICATION_STATUS.connected,
+//                   },
+//               ]}
+//              />
+//         </div>
+//     </>
+// );
+
+export const AuthorizedStudiesWithEmptyListStory = () => (
+    <>
+        <h2>AuthorizedStudies With Empty List</h2>
+        <div style={{width: '400px' }}>
+            <AuthorizedStudiesWidget 
+              id={'1'}
+              authorizedStudies={{
+                loading: false,
+                error: false,
+                studies: []
+              }}
+              services={services}
+              queryProps={queryProps}
+              fences= {[
+                  {
+                      acl: [],
+                      error: false,
+                      id: 'fence1',
+                      loading: false,
+                      status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                  },
+                  {
+                      acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                      error: false,
+                      id: 'fence2',
+                      loading: false,
+                      status: FENCE_AUHTENTIFICATION_STATUS.connected,
+                  },
+              ]}
+             />
+        </div>
+    </>
+);
+


### PR DESCRIPTION
# FEAT

- closes #[874](https://d3b.atlassian.net/browse/SKFP-874)

## Description
As a user with an eRA Commons login, I want to view and manage my access to controlled access studies in the Kids First (KF) data portal. Associated Registered/open access files will also be included for the controlled access studies that have both. The goal is to simplify the code complexity associated with retrieving data displayed on the front-end by pulling directly from the backend. In hopes to facilitate the handling of this issue: SKFP-868: [Authorized Studies] NCI Fence Issues
BACKLOG
 

## Acceptance Criterias
**Widget Title and Information:**

The widget title should display the number of controlled access studies accessible by the user.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/7edfd0fd-d45c-470c-b456-a514bb5ceabb)

An information icon popover should provide details about accessing controlled data with an eRA Commons account.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/11ee3d7d-44d3-4b4a-861f-59e68b775844)


**Messaging Above List:**
Display an information icon with a popover explaining the user's access to controlled data.

Include a link to "Manage your connections," opening a modal for fence selection.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1ff1502f-b04b-441c-a003-ef86fc021c6a)


**Fence Selection Modal:**

The modal should allow users to manage connections to Kids First Framework Services (repository = gen3) and NCI CRDC Framework Services (repository = dcf).
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/cc6d82ed-bd05-495d-82d1-b31e9bf22619)

Provide information about connecting accounts and following data use limitations.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/ba1c1c06-fd43-4930-89a4-f8dfc0f19e6e)


**Fence Selection State:**

Display the state based on fence connections (connected/disconnected). Indicate which fence(s) are connected and display controlled access studies permitted by the user for each fence.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6b63fd3e-6bbe-4cb3-80ba-fd018a9aba38)


**Empty Widget States:**

Display a message if both fences are disconnected, guiding the user to connect using NIH credentials.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/fbb6b694-8e22-4637-89d1-4c20de23bcb2)

If at least one fence is connected but no accesses, inform the user and provide a link to apply for data access.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/c23ce4dc-be49-4b24-9956-ddaa47631b0f)


**Widget State with Study List:**

List controlled access studies based on the connected fence(s).
Display study names with study codes, providing a tooltip for long names.
Include a line describing the number of files the user has access to based on consent code/acl and number of registered access files when it applies to the study.
Provide links to redirect to Data Exploration for further details on access.
List consent codes/acls associated with the user's permissions for each study.
Include a progress bar highlighting the completeness of user access.
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6321c59a-cca9-4c5f-b5f9-4aa603adea7d)


## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/ac38456c-eea4-4828-ae80-a77916a05dcb)

https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/c51e196d-056b-4d51-8004-48f88e4e4119

