### PR TITLE
fix(pill): FLUI-115 manage icon display in QB

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 8.0.3 2024-01-26
+- fix: FLUI-115 manage custom pill display in QB
+
 ### 8.0.2 2024-01-24
 - fix: SKFP-895 fix form submit error (cherry-pick from 7.20.3)
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "8.0.2",
+    "version": "8.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "8.0.2",
+    "version": "8.0.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/QueryBar.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryBar.tsx
@@ -188,26 +188,30 @@ const QueryBar = ({
                 </Space>
                 {!actionDisabled && (
                     <Space className={styles.actions} size={4}>
-                        <Tooltip
-                            title={
-                                isSaveCustomPillDisabled
-                                    ? dictionary.actions?.saveCustomPill?.tooltip?.disabled ||
-                                      'Custom queries cannot include other custom queries'
-                                    : dictionary.actions?.saveCustomPill?.tooltip?.enabled || 'Save as a custom query'
-                            }
-                        >
-                            <Button
-                                className={`${styles.actionButton} ${styles.actionButtonWithTooltip}`}
-                                disabled={isSaveCustomPillDisabled}
-                                icon={<SaveOutlined />}
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    setIsSaveCustomPillModalVisible(true);
-                                }}
-                                size="small"
-                                type="text"
-                            />
-                        </Tooltip>
+                        {/* Tag is checked to define if we want custom pill in QB. We could check each prop in config but tag is linked to backend. */}
+                        {customPillConfig.tag && (
+                            <Tooltip
+                                title={
+                                    isSaveCustomPillDisabled
+                                        ? dictionary.actions?.saveCustomPill?.tooltip?.disabled ||
+                                          'Custom queries cannot include other custom queries'
+                                        : dictionary.actions?.saveCustomPill?.tooltip?.enabled ||
+                                          'Save as a custom query'
+                                }
+                            >
+                                <Button
+                                    className={`${styles.actionButton} ${styles.actionButtonWithTooltip}`}
+                                    disabled={isSaveCustomPillDisabled}
+                                    icon={<SaveOutlined />}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setIsSaveCustomPillModalVisible(true);
+                                    }}
+                                    size="small"
+                                    type="text"
+                                />
+                            </Tooltip>
+                        )}
                         <Button
                             className={styles.actionButton}
                             icon={<CopyOutlined />}


### PR DESCRIPTION
# FIX : Disable custom pill creation icon if no pill for this QB

## Description

[FLUI-115](https://ferlab-crsj.atlassian.net/browse/FLUI-115)

Acceptance Criterias
Don't display creation icon of custom pill in QB if it's not implemented for this one.

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1207" alt="Capture d’écran, le 2024-01-26 à 12 04 36" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/8951b70a-1274-4249-a399-69bf7c770e1c">

### After
![Capture d’écran, le 2024-01-26 à 12 04 47](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/7f063277-9795-4ab3-b532-6b9fe5f410fa)

