### PR TITLE
fix: FLUI-116 fix the operator tooltip in QueryBuild to be on a single line

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 8.2.1 2024-01-31
+- fix: FLUI-116 fix the operator tooltip in QueryBuild to be on a single line
+
 ### 8.2.0 2024-01-30
 - feat: FLUI-102 upgrade storybook to V7
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "8.2.0",
+    "version": "8.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "8.2.0",
+            "version": "8.2.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "8.2.0",
+    "version": "8.2.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/Combiner.tsx
+++ b/packages/ui/src/components/QueryBuilder/Combiner.tsx
@@ -24,14 +24,12 @@ const Combiner = ({ onChange, type }: ICombinerProps): JSX.Element => {
         onChange(isAndOperator() ? CombinerEnum.Or : CombinerEnum.And);
     };
 
-    const getTooltipTitle = () => `
-            ${dictionary.actions?.changeOperatorTo || 'Change operator to'}
-            ${
-                isAndOperator()
-                    ? `"${dictionary.query?.combine?.or || 'or'}"`
-                    : `"${dictionary.query?.combine?.and || 'and'}"`
-            }
-        `;
+    const getTooltipTitle = () =>
+        `${dictionary.actions?.changeOperatorTo || 'Change operator to'} ${
+            isAndOperator()
+                ? `"${dictionary.query?.combine?.or || 'or'}"`
+                : `"${dictionary.query?.combine?.and || 'and'}"`
+        }`;
 
     return (
         <div className={styles.combinerContainer}>


### PR DESCRIPTION
# FIX:  fix the operator tooltip in QueryBuild to be on a single line

- closes [#FLUI-116](https://ferlab-crsj.atlassian.net/jira/software/c/projects/FLUI/boards/7?selectedIssue=FLUI-116)

## Description

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/jira/software/c/projects/FLUI/boards/7?selectedIssue=FLUI-116)

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Before(in Include)

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/156684667/09c2690a-898c-4ffd-b151-41f72b41c78c)

## After(in Include)

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/156684667/1c9a4fb6-86ab-4156-adb9-8fe6a70a5dc2)
