### PR TITLE
fix: SJIP-704 directly connect the user if only one service is provided to authorized studies widget

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,11 +1,12 @@
+### 9.3.0 2024-02-20
+- fix: SKFP-895 fix react-router-dom issue, fix color
+- fix: SJIP-704 directly connect the user if only one service is provided to authorized studies widget
+
 ### 9.2.0 2024-02-20
 - feat: FLUI-121 update public cohort table to use new types
 
 ### 9.1.0 2024-02-19
 - feat: FLUI-121 add disabled button tooltip in Cavatica
-
-### 9.0.2 2024-02-14
-- fix: SJIP-704 directly connect the user if only one service is provided to authorized studies widget
 
 ### 9.0.1 2024-02-14
 - fix: SKFP-895 fix cavatica error message

--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -4,6 +4,9 @@
 ### 9.1.0 2024-02-19
 - feat: FLUI-121 add disabled button tooltip in Cavatica
 
+### 9.0.2 2024-02-14
+- fix: SJIP-704 directly connect the user if only one service is provided to authorized studies widget
+
 ### 9.0.1 2024-02-14
 - fix: SKFP-895 fix cavatica error message
 

--- a/packages/ui/jest.setup.js
+++ b/packages/ui/jest.setup.js
@@ -19,12 +19,3 @@ Object.defineProperty(window, 'matchMedia', {
     })),
     writable: true,
 });
-
-jest.mock(
-    'react-router-dom',
-    () => ({
-        BrowserRouter: ({ children }) => children,
-        Link: ({ children }) => children,
-    }),
-    { virtual: true },
-);

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.2.0",
+    "version": "9.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.2.0",
+            "version": "9.3.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -28,8 +28,6 @@
                 "query-string": "^7.0.1",
                 "react-grid-layout": "^1.4.4",
                 "react-icons": "^4.2.0",
-                "react-router": "^6.22.0",
-                "react-router-dom": "^6.22.0",
                 "react-sizeme": "^3.0.2",
                 "simplebar-react": "^2.4.3",
                 "uuid": "^8.3.2"
@@ -48,7 +46,6 @@
                 "@types/md5": "^2.3.2",
                 "@types/react": "^18.2.0",
                 "@types/react-grid-layout": "^1.3.5",
-                "@types/react-router-dom": "^5.3.3",
                 "@types/uuid": "^8.3.0",
                 "@typescript-eslint/eslint-plugin": "^4.10.0",
                 "@typescript-eslint/parser": "^4.10.0",
@@ -1832,14 +1829,6 @@
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
-        "node_modules/@remix-run/router": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
-            "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2146,12 +2135,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/history": {
-            "version": "4.7.11",
-            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-            "dev": true
-        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2295,27 +2278,6 @@
             "integrity": "sha512-1CM48Y9ztL5S4wjt7DK2izrkgPp/Ql0zCJu/vHzhgl7J+BD4UbSGjHN1M2TlePms472JvOazUtAO1/G3oFZqIQ==",
             "dependencies": {
                 "@types/react": "*"
-            }
-        },
-        "node_modules/@types/react-router": {
-            "version": "5.1.20",
-            "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-            "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-            "dev": true,
-            "dependencies": {
-                "@types/history": "^4.7.11",
-                "@types/react": "*"
-            }
-        },
-        "node_modules/@types/react-router-dom": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-            "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-            "dev": true,
-            "dependencies": {
-                "@types/history": "^4.7.11",
-                "@types/react": "*",
-                "@types/react-router": "*"
             }
         },
         "node_modules/@types/scheduler": {
@@ -9274,36 +9236,6 @@
             },
             "peerDependencies": {
                 "react": ">= 16.3"
-            }
-        },
-        "node_modules/react-router": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
-            "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
-            "dependencies": {
-                "@remix-run/router": "1.15.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8"
-            }
-        },
-        "node_modules/react-router-dom": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
-            "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
-            "dependencies": {
-                "@remix-run/router": "1.15.0",
-                "react-router": "6.22.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
             }
         },
         "node_modules/react-sizeme": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.2.0",
+    "version": "9.3.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"
@@ -50,7 +50,6 @@
         "@types/md5": "^2.3.2",
         "@types/react": "^18.2.0",
         "@types/react-grid-layout": "^1.3.5",
-        "@types/react-router-dom": "^5.3.3",
         "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.10.0",
         "@typescript-eslint/parser": "^4.10.0",
@@ -113,8 +112,6 @@
         "query-string": "^7.0.1",
         "react-grid-layout": "^1.4.4",
         "react-icons": "^4.2.0",
-        "react-router": "^6.22.0",
-        "react-router-dom": "^6.22.0",
         "react-sizeme": "^3.0.2",
         "simplebar-react": "^2.4.3",
         "uuid": "^8.3.2"

--- a/packages/ui/src/components/PopoverContentLink/index.tsx
+++ b/packages/ui/src/components/PopoverContentLink/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Link, LinkProps } from 'react-router-dom';
 import { Button, ButtonProps } from 'antd';
 
 import ExternalLink from '../ExternalLink';
 
 import styles from './index.module.scss';
 
-type TPopoverContentLink = Omit<LinkProps, 'to'> & {
+type TPopoverContentLink = {
+    className?: string;
     title: string;
     externalHref?: string;
     to?: any;
@@ -28,9 +28,9 @@ const PopoverContentLink = ({ externalHref, title, to, ...linkProps }: TPopoverC
     }
 
     return (
-        <Link to={to} {...linkProps}>
+        <a href={to} {...linkProps}>
             <Button {...buttonProps}>{title}</Button>
-        </Link>
+        </a>
     );
 };
 

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.module.scss
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.module.scss
@@ -9,6 +9,7 @@
       height: unset;
       font-size: 12px;
       color: $gray-8;
+      text-decoration: underline;
     }
   }
 

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.test.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 
 import { numberWithCommas } from '../../../utils/numberUtils';
@@ -39,11 +38,7 @@ describe('AuthorizedStudiesListItem', () => {
             queryProps,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesListItem {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesListItem {...props} />);
 
         // text
         expect(screen.getByText(dictionary.authorization)).toBeTruthy();

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, List, Progress, Space, Typography } from 'antd';
+import { List, Progress, Space, Typography } from 'antd';
 import cx from 'classnames';
 
 import { generateQuery, generateValueFilter } from '../../../data/sqon/utils';
@@ -56,6 +56,7 @@ const AuthorizedStudiesListItem = ({
                         <Space size={4}>
                             <span>{dictionary.authorization}</span>
                             <a
+                                className={styles.fileLink}
                                 href={queryProps.to}
                                 onClick={() => {
                                     addQuery({
@@ -78,12 +79,11 @@ const AuthorizedStudiesListItem = ({
                                     });
                                 }}
                             >
-                                <Button className={styles.fileLink} type="link">
-                                    <span>{numberWithCommas(authorizedAndUncontrolledFilesCount)}</span>
-                                </Button>
+                                <span>{numberWithCommas(authorizedAndUncontrolledFilesCount)}</span>
                             </a>
                             <span className={styles.of}>{dictionary.of}</span>
                             <a
+                                className={styles.fileLink}
                                 href={queryProps.to}
                                 onClick={() => {
                                     addQuery({
@@ -101,9 +101,7 @@ const AuthorizedStudiesListItem = ({
                                     });
                                 }}
                             >
-                                <Button className={styles.fileLink} type="link">
-                                    <span>{numberWithCommas(data.total_files_count)}</span>
-                                </Button>
+                                <span>{numberWithCommas(data.total_files_count)}</span>
                             </a>
                             <span>{dictionary.files}</span>
                         </Space>

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/AuthorizedStudiesListItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Button, List, Progress, Space, Typography } from 'antd';
 import cx from 'classnames';
 

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/index.test.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/index.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { MinusCircleFilled, PlusCircleFilled } from '@ant-design/icons';
 import { render, screen } from '@testing-library/react';
 
@@ -87,11 +86,7 @@ describe('AuthorizedStudiesWidget', () => {
             services,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.findAllByRole('loading')).toBeTruthy();
     });
 
@@ -119,11 +114,7 @@ describe('AuthorizedStudiesWidget', () => {
             services,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.getByText(dictionary.authentification.action)).toBeTruthy();
         expect(screen.getByText(dictionary.authentification.description)).toBeTruthy();
     });
@@ -153,11 +144,7 @@ describe('AuthorizedStudiesWidget', () => {
             services,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.getByText(dictionary.manageConnections)).toBeTruthy();
         expect(screen.getByText(dictionary.connectedNotice)).toBeTruthy();
         expect(screen.queryAllByText(dictionary.list.authorization)).toHaveLength(2);
@@ -195,11 +182,7 @@ describe('AuthorizedStudiesWidget', () => {
             services,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.getByText(dictionary.manageConnections)).toBeTruthy();
         expect(screen.getByText(dictionary.noAvailableStudies)).toBeTruthy();
     });
@@ -228,11 +211,7 @@ describe('AuthorizedStudiesWidget', () => {
             services,
         };
 
-        render(
-            <BrowserRouter>
-                <AuthorizedStudiesWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.getByText(dictionary.error.title)).toBeTruthy();
         expect(screen.getByText(dictionary.error.subtitle, { exact: false })).toBeTruthy();
         expect(screen.getByText(dictionary.error.contactSupport)).toBeTruthy();

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.test.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import CavaticaAnalyse, { DEFAULT_CAVATICA_ANALYSE_DICTIONARY } from './CavaticaAnalyse';
@@ -62,11 +61,7 @@ describe('Cavatica Analyse', () => {
             setCavaticaBulkImportDataStatus: jest.fn(),
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaAnalyse {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaAnalyse {...props} />);
         const button = screen.getByRole('button', { name: dictionary.buttonText });
         expect(button).toBeTruthy();
     });
@@ -125,11 +120,7 @@ describe('Cavatica Analyse', () => {
             setCavaticaBulkImportDataStatus: jest.fn(),
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaAnalyse {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaAnalyse {...props} />);
 
         const button = screen.getByRole('button', { name: dictionary.buttonText });
         expect(button).toBeTruthy();
@@ -192,11 +183,7 @@ describe('Cavatica Analyse', () => {
             setCavaticaBulkImportDataStatus: jest.fn(),
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaAnalyse {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaAnalyse {...props} />);
 
         const button = screen.getByRole('button', { name: dictionary.buttonText });
         expect(button).toBeTruthy();

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { CloudUploadOutlined } from '@ant-design/icons';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { Button, Modal, Tooltip } from 'antd';
 import { BaseButtonProps } from 'antd/lib/button/button';
 
@@ -38,10 +39,11 @@ export const DEFAULT_CAVATICA_ANALYSE_DICTIONARY: TCavaticaAnalyseDictionary = {
     analyseModal: DEFAULT_CAVATICA_ANALYSE_MODAL_DICTIONARY,
     buttonText: 'Analyze in Cavatica',
     connectionRequiredModal: {
+        cancelText: 'Cancel',
         description:
             'In order to analyze your files you must first connect your Cavatica account. Once you are connected, you will be redirected back to this page.',
         okText: 'Connect',
-        title: 'You are not connected to Cavatica',
+        title: 'Connect to Cavatica',
     },
     createProjectModal: DEFAULT_CAVATICA_CREATE_PROJECT_MODAL_DICTIONARY,
     disabledButtonTooltip: 'You must select at least 1 item',
@@ -70,6 +72,7 @@ export type TCavaticaAnalyseDictionary = {
         title: string;
         description: string;
         okText: string;
+        cancelText: string;
     };
     disabledButtonTooltip: string;
     buttonText: string;
@@ -156,6 +159,7 @@ const CavaticaAnalyse = ({
         if (!errorProps) {
             return;
         }
+
         Modal.error({
             ...errorProps,
             onOk: () => {
@@ -170,12 +174,15 @@ const CavaticaAnalyse = ({
             return;
         }
 
-        Modal.warning({
+        Modal.confirm({
+            cancelText: dictionary.connectionRequiredModal.cancelText,
             content: dictionary?.connectionRequiredModal?.description,
+            icon: <ExclamationCircleOutlined />,
             okText: dictionary.connectionRequiredModal?.okText,
             onCancel: onResetModal,
             onOk: () => handleConnection(),
             title: dictionary?.connectionRequiredModal?.title,
+            type: 'warn',
         });
     }, [modalState]);
 

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyseModal.test.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyseModal.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 
 import CavaticaAnalyseModal, { DEFAULT_CAVATICA_ANALYSE_MODAL_DICTIONARY } from './CavaticaAnalyzeModal';
@@ -64,11 +63,7 @@ describe('CavaticaAnalyseModal', () => {
             },
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaAnalyseModal {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaAnalyseModal {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.getByText(dictionary.files.replace('{files}', `${1}`))).toBeTruthy();
     });

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyzeModal.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyzeModal.tsx
@@ -21,7 +21,7 @@ export const DEFAULT_CAVATICA_ANALYSE_MODAL_DICTIONARY: TCavaticaAnalyseModalDic
     files: '{files} files',
     newProject: 'New project',
     ofFiles: '(out of {files} selected) to your Cavatica workspace.',
-    title: 'Connect in Cavatica',
+    title: 'Analyze in Cavatica',
     youAreAuthorizedToCopy: 'You are authorized to copy',
 };
 

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.test.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import { fireEvent, getByText, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { DEFAULT_CAVATICA_CREATE_PROJECT_MODAL_DICTIONARY } from './CavaticaCreateProjectModal';
 import CavaticaCreateProjectModal from './CavaticaCreateProjectModal';
@@ -30,11 +29,7 @@ describe('CavaticaCreateProjectModal', () => {
             open: true,
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaCreateProjectModal {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaCreateProjectModal {...props} />);
         expect(screen.getAllByText(dictionary.title).length).toBe(2);
         expect(screen.getByText(dictionary.billingGroup.label)).toBeTruthy();
 
@@ -74,11 +69,7 @@ describe('CavaticaCreateProjectModal', () => {
             open: true,
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaCreateProjectModal {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaCreateProjectModal {...props} />);
 
         expect(screen.getAllByText(dictionary.title).length).toBe(2);
         expect(screen.getByText(dictionary.billingGroup.label)).toBeTruthy();

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaListItem.test.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaListItem.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 
 import CavaticaListItem from './CavaticaListItem';
@@ -25,11 +24,7 @@ describe('CavaticaListItem', () => {
             },
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaListItem {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaListItem {...props} />);
         expect(screen.getByText(props.project.name)).toBeTruthy();
         expect(screen.getByText(dictionary.membersCount(props.project.memberCount))).toBeTruthy();
     });

--- a/packages/ui/src/components/Widgets/Cavatica/index.test.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/index.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { PASSPORT_AUTHENTIFICATION_STATUS } from './type';
@@ -54,11 +53,7 @@ describe('CavaticaWidget', () => {
             id: '1',
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaWidget {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.findAllByRole('loading')).toBeTruthy();
     });
@@ -109,11 +104,7 @@ describe('CavaticaWidget', () => {
             id: '1',
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaWidget {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.getByText(dictionary.connectCard?.action)).toBeTruthy();
         expect(screen.getByText(dictionary.connectCard?.description)).toBeTruthy();
@@ -223,11 +214,7 @@ describe('CavaticaWidget', () => {
             id: '1',
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaWidget {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.getByText(dictionary.connectedNotice)).toBeTruthy();
         expect(screen.getByText(dictionary.disconnect)).toBeTruthy();
@@ -296,11 +283,7 @@ describe('CavaticaWidget', () => {
             id: '1',
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaWidget {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.getByText(dictionary.connectedNotice)).toBeTruthy();
         expect(screen.getByText(dictionary.disconnect)).toBeTruthy();
@@ -353,11 +336,7 @@ describe('CavaticaWidget', () => {
             id: '1',
         };
 
-        render(
-            <BrowserRouter>
-                <CavaticaWidget {...props} />
-            </BrowserRouter>,
-        );
+        render(<CavaticaWidget {...props} />);
         expect(screen.getByText(dictionary.title)).toBeTruthy();
         expect(screen.getByText(dictionary.error.fetch.title)).toBeTruthy();
     });

--- a/packages/ui/src/components/Widgets/Cavatica/index.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { DisconnectOutlined, PlusOutlined, SafetyOutlined } from '@ant-design/icons';
-import { Button, List, Modal, Result, Space, Typography } from 'antd';
+import { Button, List, Result, Space, Typography } from 'antd';
 import cx from 'classnames';
 
 import GridCard, { GridCardHeader } from '../../../view/v2/GridCard';

--- a/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTableRedirectLink/index.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
 import { Space } from 'antd';
 
 import styles from './index.module.scss';
@@ -12,12 +11,12 @@ type TEntityTableRedirectLink = {
 };
 
 const EntityTableRedirectLink = (props: TEntityTableRedirectLink): JSX.Element => (
-    <Link className={styles.link} {...props}>
+    <a className={styles.link} href={props.to} {...props}>
         <Space size={4}>
             <span className={styles.content}>{props.children}</span>
             <span className={styles.icon}>{props.icon}</span>
         </Space>
-    </Link>
+    </a>
 );
 
 export default EntityTableRedirectLink;

--- a/packages/ui/themes/default/_antd.scss
+++ b/packages/ui/themes/default/_antd.scss
@@ -1,5 +1,21 @@
+@import 'colors';
+
 .ant-space-compact-block {
   display: inline-flex;
   width: unset;
   max-width: 100%
+}
+
+.ant-modal-confirm {
+    .ant-modal-confirm-body > .anticon {
+        color: $orange-7;
+    }
+
+    &.ant-modal-confirm-warning .ant-modal-confirm-body > .anticon {
+        color: $orange-7;
+    }
+
+    &.ant-modal-confirm-error .ant-modal-confirm-body > .anticon {
+        color: $red-7;
+    }
 }

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -12,9 +12,7 @@
                 "@ferlab/ui": "file:../packages/ui",
                 "antd": "^4.24.10",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "react-router": "^5.2.0",
-                "react-router-dom": "^5.2.0"
+                "react-dom": "^18.2.0"
             },
             "devDependencies": {
                 "@babel/core": "^7.23.6",
@@ -50,7 +48,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "9.0.0",
+            "version": "9.3.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -72,8 +70,6 @@
                 "query-string": "^7.0.1",
                 "react-grid-layout": "^1.4.4",
                 "react-icons": "^4.2.0",
-                "react-router": "^6.22.0",
-                "react-router-dom": "^6.22.0",
                 "react-sizeme": "^3.0.2",
                 "simplebar-react": "^2.4.3",
                 "uuid": "^8.3.2"
@@ -92,7 +88,6 @@
                 "@types/md5": "^2.3.2",
                 "@types/react": "^18.2.0",
                 "@types/react-grid-layout": "^1.3.5",
-                "@types/react-router-dom": "^5.3.3",
                 "@types/uuid": "^8.3.0",
                 "@typescript-eslint/eslint-plugin": "^4.10.0",
                 "@typescript-eslint/parser": "^4.10.0",
@@ -10647,27 +10642,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/history": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-            "dependencies": {
-                "@babel/runtime": "^7.1.2",
-                "loose-envify": "^1.2.0",
-                "resolve-pathname": "^3.0.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0",
-                "value-equal": "^1.0.1"
-            }
-        },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -13621,6 +13595,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14417,6 +14392,7 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -15335,7 +15311,8 @@
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
         },
         "node_modules/react-refresh": {
             "version": "0.14.0",
@@ -15391,55 +15368,6 @@
                 "@types/react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/react-router": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-            "dependencies": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "hoist-non-react-statics": "^3.1.0",
-                "loose-envify": "^1.3.1",
-                "path-to-regexp": "^1.7.0",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.6.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=15"
-            }
-        },
-        "node_modules/react-router-dom": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "loose-envify": "^1.3.1",
-                "prop-types": "^15.6.2",
-                "react-router": "5.3.4",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=15"
-            }
-        },
-        "node_modules/react-router/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "node_modules/react-router/node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dependencies": {
-                "isarray": "0.0.1"
             }
         },
         "node_modules/react-style-singleton": {
@@ -15859,11 +15787,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/resolve-pathname": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "node_modules/resolve-url": {
             "version": "0.2.1",
@@ -17309,12 +17232,8 @@
         "node_modules/tiny-invariant": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-            "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+            "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+            "dev": true
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -18195,11 +18114,6 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
-        },
-        "node_modules/value-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "node_modules/vary": {
             "version": "1.1.2",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -46,8 +46,6 @@
         "@ferlab/ui": "file:../packages/ui",
         "antd": "^4.24.10",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router": "^5.2.0",
-        "react-router-dom": "^5.2.0"
+        "react-dom": "^18.2.0"
     }
 }

--- a/storybook/stories/Components/AuthorizedStudies/AuthorizedStudies.stories.tsx
+++ b/storybook/stories/Components/AuthorizedStudies/AuthorizedStudies.stories.tsx
@@ -69,10 +69,11 @@ export default {
     ],
 } as Meta;
 
-export const AuthorizedStudiesBasicStory = () => (
+
+export const AuthorizedStudiesLoadingStory = () => (
     <>
-        <h2>AuthorizedStudies with disconnected fences</h2>
-        <div style={{width: '400px' }}>
+        <h2>AuthorizedStudies loading</h2>
+        <div>
                 <AuthorizedStudiesWidget 
                 id={'1'} 
                 authorizedStudies={{
@@ -103,41 +104,195 @@ export const AuthorizedStudiesBasicStory = () => (
     </>
 );
 
-// React-router is broken with our current version, wait for new storybook to uncomment
-// export const AuthorizedStudiesWithStudiesStory = () => (
-//     <>
-//         <h2>AuthorizedStudies With Connected Fences</h2>
-//         <div style={{width: '400px' }}>
-//             <AuthorizedStudiesWidget 
-//               id={'1'}
-//               authorizedStudies={authorizedStudies}
-//               services={services}
-//               queryProps={queryProps}
-//               fences= {[
-//                   {
-//                       acl: [],
-//                       error: false,
-//                       id: 'fence1',
-//                       loading: false,
-//                       status: FENCE_AUTHENTIFICATION_STATUS.connected,
-//                   },
-//                   {
-//                       acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
-//                       error: false,
-//                       id: 'fence2',
-//                       loading: false,
-//                       status: FENCE_AUTHENTIFICATION_STATUS.connected,
-//                   },
-//               ]}
-//              />
-//         </div>
-//     </>
-// );
 
-export const AuthorizedStudiesWithEmptyListStory = () => (
+
+export const AuthorizedStudiesSingleServiceDisconnectedStory = () => (
     <>
-        <h2>AuthorizedStudies With Empty List</h2>
-        <div style={{width: '400px' }}>
+        <h2>AuthorizedStudies with a single service and disconnected fences</h2>
+        <div>
+                <AuthorizedStudiesWidget 
+                id={'1'} 
+                authorizedStudies={{
+                    loading: false,
+                    error: false,
+                    studies: []
+                }}
+                services={[services[0]]}
+                queryProps={queryProps}
+                fences={[
+                    {
+                        acl: [],
+                        error: false,
+                        id: 'fence1',
+                        loading: false,
+                        status: FENCE_AUTHENTIFICATION_STATUS.disconnected,
+                    },
+                ]}
+                />
+        </div>
+    </>
+);
+
+export const AuthorizedStudiesWithASingleServiceStory = () => (
+    <>
+        <h2>AuthorizedStudies With a single service</h2>
+        <div>
+            <AuthorizedStudiesWidget 
+              id={'1'}
+              authorizedStudies={{
+                loading: false,
+                error: false,
+                studies: []
+              }}
+              services={[services[0]]}
+              queryProps={queryProps}
+              fences= {[
+                  {
+                      acl: [],
+                      error: false,
+                      id: 'fence1',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+                  {
+                      acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                      error: false,
+                      id: 'fence2',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+              ]}
+             />
+        </div>
+    </>
+);
+
+
+export const AuthorizedStudiesSingleServiceWithStudiesStory = () => (
+    <>
+        <h2>AuthorizedStudies With a single service and Connected Fences</h2>
+        <div>
+            <AuthorizedStudiesWidget 
+              id={'1'}
+              authorizedStudies={authorizedStudies}
+              services={[services[0]]}
+              queryProps={queryProps}
+              fences= {[
+                  {
+                      acl: [],
+                      error: false,
+                      id: 'fence1',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+                  {
+                      acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                      error: false,
+                      id: 'fence2',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+              ]}
+             />
+        </div>
+    </>
+);
+
+export const AuthorizedStudiesSingleServiceWithEmptyListStory = () => (
+    <>
+        <h2>AuthorizedStudies with a single service With and empty List</h2>
+        <div>
+            <AuthorizedStudiesWidget 
+              id={'1'}
+              authorizedStudies={{
+                loading: false,
+                error: false,
+                studies: []
+              }}
+              services={[services[0]]}
+              queryProps={queryProps}
+              fences= {[
+                  {
+                      acl: [],
+                      error: false,
+                      id: 'fence1',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  }
+              ]}
+             />
+        </div>
+    </>
+);
+
+export const AuthorizedStudiesMultiServiceDisconnectedStory = () => (
+    <>
+        <h2>AuthorizedStudies with multi-service and disconnected fences</h2>
+        <div>
+                <AuthorizedStudiesWidget 
+                id={'1'} 
+                authorizedStudies={{
+                    loading: false,
+                    error: false,
+                    studies: []
+                }}
+                services={services}
+                queryProps={queryProps}
+                fences={[
+                    {
+                        acl: [],
+                        error: false,
+                        id: 'fence1',
+                        loading: false,
+                        status: FENCE_AUTHENTIFICATION_STATUS.disconnected,
+                    },
+                    {
+                        acl: [],
+                        error: false,
+                        id: 'fence2',
+                        loading: false,
+                        status: FENCE_AUTHENTIFICATION_STATUS.disconnected,
+                    },
+                ]}
+                />
+        </div>
+    </>
+);
+
+export const AuthorizedStudiesMultiServiceWithStudiesStory = () => (
+    <>
+        <h2>AuthorizedStudies With multi-service and Connected Fences</h2>
+        <div>
+            <AuthorizedStudiesWidget 
+              id={'1'}
+              authorizedStudies={authorizedStudies}
+              services={services}
+              queryProps={queryProps}
+              fences= {[
+                  {
+                      acl: [],
+                      error: false,
+                      id: 'fence1',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+                  {
+                      acl: ['xxxxx1.x1', 'xxxxx2.x2', 'xxxxx3.x3'],
+                      error: false,
+                      id: 'fence2',
+                      loading: false,
+                      status: FENCE_AUTHENTIFICATION_STATUS.connected,
+                  },
+              ]}
+             />
+        </div>
+    </>
+);
+
+export const AuthorizedStudiesMultiServiceWithEmptyListStory = () => (
+    <>
+        <h2>AuthorizedStudies with multi-service With and empty List</h2>
+        <div>
             <AuthorizedStudiesWidget 
               id={'1'}
               authorizedStudies={{


### PR DESCRIPTION
# Fix

- closes #704

## Description

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-704)

Includee ne supporte qu'une seule fence, donc afin d'éviter une modal inutile, si on envoie qu'un seul service à l'authorized studies widget, la connection se fera directement au clique sur bouton

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/eee1f3c0-275e-4699-b878-fe7e49a498ad)
