### PR TITLE
fix(entity description): SJIP-710 manage empty descriptions

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.6.6 2024-03-06
+- fix: SJIP-710 manage no data in Entity Description
+
 ### 9.6.5 2024-03-06
 - fix: SKFP-924 fix authorized studies widget title
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.6.5",
+    "version": "9.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.6.5",
+            "version": "9.6.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.6.5",
+    "version": "9.6.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityDescriptions/index.test.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityDescriptions/index.test.tsx
@@ -53,4 +53,23 @@ describe('EntityPage/EntityDescription', () => {
         expect(screen.getByText('Header')).toBeTruthy();
         expect(screen.getByText('SubHeader')).toBeTruthy();
     });
+
+    test('should render empty if descriptions is an empty array', () => {
+        const props = {
+            descriptions: [],
+            header: 'Header',
+            id: 'ID',
+            loading: false,
+            subheader: <>SubHeader</>,
+            title: 'Title',
+        };
+        render(<EntityDescription {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.getByText('Header')).toBeTruthy();
+        expect(screen.getByText('No data available')).toBeTruthy();
+
+        expect(screen.queryByText('label 1')).toBeNull();
+        expect(screen.queryByText('value 3')).toBeNull();
+        expect(screen.queryByText('SubHeader')).toBeNull();
+    });
 });

--- a/packages/ui/src/pages/EntityPage/EntityDescriptions/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityDescriptions/index.tsx
@@ -3,19 +3,21 @@ import { Card, Descriptions, Space, Typography } from 'antd';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from '../../../common/constants';
 import Collapse, { CollapsePanel } from '../../../components/Collapse';
+import Empty from '../../../components/Empty';
 
 import styles from './index.module.scss';
 
 const { Title } = Typography;
 
 export interface IEntityDescriptions {
-    id?: string;
     descriptions: IEntityDescriptionsItem[];
+    header: string;
+    id?: string;
     loading: boolean;
+    noDataLabel?: string;
+    subheader?: React.ReactNode;
     title?: string;
     titleExtra?: ReactNode[];
-    header: string;
-    subheader?: React.ReactNode;
 }
 
 export interface IEntityDescriptionsItem {
@@ -29,6 +31,7 @@ const EntityDescriptions: React.FC<IEntityDescriptions> = ({
     header,
     id = '',
     loading,
+    noDataLabel = 'No data available',
     subheader,
     title,
     titleExtra,
@@ -42,16 +45,20 @@ const EntityDescriptions: React.FC<IEntityDescriptions> = ({
         <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
             <CollapsePanel className={styles.panel} extra={titleExtra} header={header} key="1">
                 <Card className={styles.card} loading={loading}>
-                    <Space className={styles.content} direction="vertical" size={0}>
-                        {subheader}
-                        <Descriptions bordered column={1} size="small">
-                            {descriptions.map((description, index) => (
-                                <Descriptions.Item key={`${description.label}:${index}`} label={description.label}>
-                                    {description.value || TABLE_EMPTY_PLACE_HOLDER}
-                                </Descriptions.Item>
-                            ))}
-                        </Descriptions>
-                    </Space>
+                    {descriptions.length > 0 ? (
+                        <Space className={styles.content} direction="vertical" size={0}>
+                            {subheader}
+                            <Descriptions bordered column={1} size="small">
+                                {descriptions.map((description, index) => (
+                                    <Descriptions.Item key={`${description.label}:${index}`} label={description.label}>
+                                        {description.value || TABLE_EMPTY_PLACE_HOLDER}
+                                    </Descriptions.Item>
+                                ))}
+                            </Descriptions>
+                        </Space>
+                    ) : (
+                        <Empty align="left" description={noDataLabel} noPadding showImage={false} />
+                    )}
                 </Card>
             </CollapsePanel>
         </Collapse>


### PR DESCRIPTION
# FIX : Manage empty descriptions props

## Description

[SJIP-710](https://d3b.atlassian.net/browse/SJIP-710)

Acceptance Criterias
- if no descriptions display empty component

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="1548" alt="Capture d’écran, le 2024-03-06 à 10 15 35" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/0a0b7f88-1c51-4c7b-a419-6167f1508ed5">
