### PR TITLE
Fix/fl UI 128

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.9.2 2024-03-22
+- fix: FLUI-128 Fix expandablecell style
+
 ### 9.9.1 2024-03-21
 - fix: SJIP-711 Fix Entity Statistic style
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.9.1",
+    "version": "9.9.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.9.1",
+            "version": "9.9.2",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.9.1",
+    "version": "9.9.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/tables/ExpandableCell/index.module.scss
+++ b/packages/ui/src/components/tables/ExpandableCell/index.module.scss
@@ -1,4 +1,4 @@
-.fuiExpandableCellBtn {
+a.fuiExpandableCellBtn {
   font-size: 12px;
   text-decoration: underline;
   display: block;


### PR DESCRIPTION
# FIX

- closes #[128](https://ferlab-crsj.atlassian.net/browse/FLUI-128)

## Description
L'underline se fait surchargé par la classe Typography dans les projets clients.

https://ferlab-crsj.atlassian.net/browse/FLUI-128


## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/91792ba2-8f26-4cac-bdb7-471af927b74e)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/5348051e-3462-49dd-bd67-9188a0b60c02)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/82538e05-c3ad-4dce-a4a3-ba697015f4e4)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/2b1a5a21-16f0-4d8a-9de3-9c464800e783)

