### PR TITLE
fix(tag): SKFP-1003 fix not applicable tag

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.9.7 2024-04-3
+- fix: SKFP-1003 fix not applicable tag
+
 ### 9.9.6 2024-04-3
 - fix: SJIP-756 fix typo in item count pro table
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.9.6",
+    "version": "9.9.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.9.6",
+            "version": "9.9.7",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.9.6",
+    "version": "9.9.7",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityConditionsCell/InheritanceTag.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityConditionsCell/InheritanceTag.tsx
@@ -18,6 +18,7 @@ const geneticTypes: GeneticTypes = {
     mitochondrial: 'Mi',
     multifactorial: 'Mu',
     'no reported transmission': 'NRT',
+    'not applicable': 'NA',
     'somatic mosaicism': 'SMo',
     'somatic mutation': 'Smu',
     unknown: null,


### PR DESCRIPTION
# FIX 

- closes #[1003](https://d3b.atlassian.net/browse/SKFP-1003)

## Description
Dans le tableau Gene - Phenotype Association de la page Variant Entity, le tag “Not Applicable” s’affiche mal.

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1003)

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1e0d97e9-e3fc-4429-a875-4df2999d1cbc)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/e8ba4ee8-591b-4de6-9a84-00f059d5f01e)
