### PR TITLE
feat(statistic): SJIP-773 add excludeZeroValue to statistic graph

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.10.1 2024-04-5
+- fix: SJIP-773 add excludeZeroValue
+
 ### 9.10.1 2024-04-4
 - fix: prevent error when getting header size
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.10.1",
+    "version": "9.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.10.1",
+            "version": "9.11.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.10.1",
+    "version": "9.11.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityStatistics/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityStatistics/index.tsx
@@ -97,6 +97,7 @@ type TEntityStatisticsDictionary = {
 type TStatisticFilter = {
     total?: number;
     unique?: boolean;
+    excludeZeroValue?: boolean;
     excludes?: string[];
 };
 
@@ -167,6 +168,11 @@ const applyFilter = ({ data, filter }: TStatisticBarChart | TStatisticPieChart, 
     }
 
     let result = data as any[];
+
+    if (filter.excludeZeroValue) {
+        result = result.filter((item) => item.value > 0);
+    }
+
     if (filter.excludes) {
         result = result.filter((item) => !filter.excludes?.includes((item as any)[key]));
     }


### PR DESCRIPTION
# FEAT 

- closes #[773](https://d3b.atlassian.net/browse/SJIP-773)

## Description

Modify the charts to not show results that are at 0. Only show the bar with values >1 

[[JIRA LINK](https://d3b.atlassian.net/browse/SJIP-773)]


## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/0a9ccf6a-d3d0-4533-87e0-731cc36e6413)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/dfcac78b-9d89-47bf-82d3-a489d076d1f6)


