### PR TITLE
fix(statiticIcon): SJIP-771 fix style

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.11.2 2024-04-8
+- feat: SJIP-771 change statistic icon style behavior
+
 ### 9.11.1 2024-04-8
 - feat: SJIP-775 change header dataset entity type
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.11.1",
+    "version": "9.11.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/StatisticIcon/index.module.scss
+++ b/packages/ui/src/components/StatisticIcon/index.module.scss
@@ -3,13 +3,22 @@
 .statisticWrapper {
     display: flex;
     align-items: center;
+    justify-content: center;;
     gap: 16px;
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        justify-content: start;
+        margin-bottom: 6px;
+    }
 
     .count {
         font-weight: 600 !important;
         font-size: 16px;
         line-height: 24px;
         color: $gray-8;
+        text-align: left;
     }
 
     .label {
@@ -17,5 +26,16 @@
         font-size: 14px;
         line-height: 22px;
         color: $gray-8;
+        text-align: left;
+    }
+
+    .icon {
+        color: $gray-8;
+    }
+
+    &.disabled {
+        .count, .label, .icon {
+            color: inherit;
+        }
     }
 }

--- a/packages/ui/src/components/StatisticIcon/index.tsx
+++ b/packages/ui/src/components/StatisticIcon/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import cx from 'classnames';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from '../../common/constants';
 import { numberFormat } from '../../utils/numberUtils';
@@ -9,12 +10,13 @@ export type TStatisticIcon = {
     count?: number;
     icon: React.ReactNode;
     label: string;
+    disabled?: boolean;
 };
 
-export const StatisticIcon = ({ count, icon, label }: TStatisticIcon): ReactElement => (
-    <div className={styles.statisticWrapper}>
-        {icon}
-        <div>
+export const StatisticIcon = ({ count, disabled, icon, label }: TStatisticIcon): ReactElement => (
+    <div className={cx(styles.statisticWrapper, { [styles.disabled]: disabled })}>
+        <div className={styles.icon}>{icon}</div>
+        <div className={styles.stats}>
             <div className={styles.count}>{count ? numberFormat(count) : TABLE_EMPTY_PLACE_HOLDER}</div>
             <span className={styles.label}>{label}</span>
         </div>


### PR DESCRIPTION
# FIX

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-771)

## Description

Afin de permettre de boutons en disabled alors qu'ils contiennent des statisticIcon, quelques modifications ont du être faite.

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-771)


## Screenshot

![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/22c2f45b-cc42-465c-aad2-02c4c18cdd95)


