### PR TITLE
fix(widget): SJIP-783 add disconnect btn to error message

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.12.3 2024-04-10
+- feat: SJIP-783 Add disconnect button to error message
+
 ### 9.12.2 2024-04-10
 - feat: CQDG-662 Add Mitochondrial inheritance tag
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.12.2",
+    "version": "9.12.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.12.2",
+            "version": "9.12.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.12.2",
+    "version": "9.12.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/index.test.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/index.test.tsx
@@ -213,7 +213,8 @@ describe('AuthorizedStudiesWidget', () => {
 
         render(<AuthorizedStudiesWidget {...props} />);
         expect(screen.getByText(dictionary.error.title)).toBeTruthy();
-        expect(screen.getByText(dictionary.error.subtitle, { exact: false })).toBeTruthy();
+        expect(screen.getByText(dictionary.error.disconnect.start, { exact: false })).toBeTruthy();
+        expect(screen.getByText(dictionary.error.disconnect.end, { exact: false })).toBeTruthy();
         expect(screen.getByText(dictionary.error.contactSupport)).toBeTruthy();
     });
 });

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/index.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ApiOutlined, SafetyOutlined } from '@ant-design/icons';
+import { ApiOutlined, DisconnectOutlined, SafetyOutlined } from '@ant-design/icons';
 import { Button, List, Result, Space } from 'antd';
 import Text from 'antd/lib/typography/Text';
 import cx from 'classnames';
@@ -35,10 +35,14 @@ export enum FENCE_AUTHENTIFICATION_STATUS {
 export const DEFAULT_AUTHORIZED_WIDGET_DICTIONARY = {
     authentification: DEFAULT_CARD_CONNECT_PLACEHOLDER_DICTIONARY,
     connectedNotice: 'You have access to the following controlled data.',
+    disconnect: 'Disconnect',
     error: {
         contactSupport: 'contact support',
+        disconnect: {
+            end: 'your account and try again. If the problem persists, please',
+            start: 'We are currently unable to connect to this service. Please refresh the page or',
+        },
         email: '',
-        subtitle: 'An error has occurred. Please try again',
         title: 'Error',
     },
     list: DEFAULT_AUTHORIZED_STUDIES_LIST_ITEM_DICTIONARY,
@@ -93,9 +97,13 @@ type TAuthorizedStudiesWidgetDictionary = {
     noAvailableStudies: string;
     authentification: TCardConnectPlaceholderDictionary;
     list: TAuthorizedStudiesListItemDictionary;
+    disconnect: string;
     error: {
         title: string;
-        subtitle: string;
+        disconnect: {
+            start: string;
+            end: string;
+        };
         contactSupport: string;
         email: string;
     };
@@ -161,7 +169,23 @@ const AuthorizedStudiesWidget = ({
                                     status="error"
                                     subTitle={
                                         <Text>
-                                            {dictionary.error.subtitle}
+                                            {dictionary.error.disconnect.start}
+                                            <Button
+                                                className={styles.disconnectErrorBtn}
+                                                danger
+                                                onClick={() => {
+                                                    if (hasMultipleServices) {
+                                                        setIsModalOpen(true);
+                                                        return;
+                                                    }
+                                                    services[0].onDisconnectFromFence();
+                                                }}
+                                                size="small"
+                                                type="link"
+                                            >
+                                                {dictionary.disconnect.toLowerCase()}
+                                            </Button>
+                                            {dictionary.error.disconnect.end}
                                             <ExternalLink
                                                 className={styles.contactSupport}
                                                 href={`mailto:${dictionary.error.email}`}
@@ -198,32 +222,30 @@ const AuthorizedStudiesWidget = ({
                         {/* List of Authorized Studies */}
                         {state === WIDGET_STATE.connected && (
                             <div className={styles.listContent}>
-                                {hasMultipleServices && (
-                                    <div className={styles.authenticatedHeader}>
-                                        <Space align="start">
-                                            <SafetyOutlined className={styles.safetyIcon} />
-                                            <Text className={styles.notice}>
-                                                {dictionary.connectedNotice}
-                                                <Button
-                                                    className={styles.disconnectBtn}
-                                                    icon={<ApiOutlined />}
-                                                    loading={authorizedStudies?.loading}
-                                                    onClick={() => {
-                                                        if (hasMultipleServices) {
-                                                            setIsModalOpen(true);
-                                                            return;
-                                                        }
-                                                        services[0].onDisconnectFromFence();
-                                                    }}
-                                                    size="small"
-                                                    type="link"
-                                                >
-                                                    {dictionary.manageConnections}
-                                                </Button>
-                                            </Text>
-                                        </Space>
-                                    </div>
-                                )}
+                                <div className={styles.authenticatedHeader}>
+                                    <Space align="start">
+                                        <SafetyOutlined className={styles.safetyIcon} />
+                                        <Text className={styles.notice}>
+                                            {dictionary.connectedNotice}
+                                            <Button
+                                                className={styles.disconnectBtn}
+                                                icon={<ApiOutlined />}
+                                                loading={authorizedStudies?.loading}
+                                                onClick={() => {
+                                                    if (hasMultipleServices) {
+                                                        setIsModalOpen(true);
+                                                        return;
+                                                    }
+                                                    services[0].onDisconnectFromFence();
+                                                }}
+                                                size="small"
+                                                type="link"
+                                            >
+                                                {dictionary.manageConnections}
+                                            </Button>
+                                        </Text>
+                                    </Space>
+                                </div>
                                 <List<IAuthorizedStudy>
                                     bordered
                                     className={styles.list}

--- a/packages/ui/src/components/Widgets/Cavatica/index.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/index.tsx
@@ -53,11 +53,13 @@ export const DEFAULT_CAVATICA_WIDGET_DICTIONARY: TCavaticaWidgetDictionary = {
     createProjectModal: DEFAULT_CAVATICA_CREATE_PROJECT_MODAL_DICTIONARY,
     disconnect: 'screen.dashboard.cards.cavatica.disconnect',
     error: {
-        contactSupport:
-            'We are currently unable to connect to this service. Please refresh the page and try again. If the problem persists, please contact support.',
+        contactSupport: 'contact support.',
         email: '',
         fetch: {
-            subtitle: 'Unable to fetch your cavatica projects.',
+            disconnect: {
+                end: 'your account and try again. If the problem persists, please',
+                start: 'We are currently unable to connect to this service. Please refresh the page or',
+            },
             title: 'Error',
         },
     },
@@ -92,7 +94,10 @@ type TCavaticaWidgetDictionary = {
     error: {
         fetch: {
             title: string;
-            subtitle: string;
+            disconnect: {
+                start: string;
+                end: string;
+            };
         };
         contactSupport: string;
         email: string;
@@ -156,7 +161,18 @@ const CavaticaWidget = ({
                                     status="error"
                                     subTitle={
                                         <Text>
-                                            {dictionary.error.fetch.subtitle}
+                                            {dictionary.error.fetch.disconnect.start}
+                                            <Button
+                                                className={styles.disconnectErrorBtn}
+                                                danger
+                                                loading={authentification.loading}
+                                                onClick={handleDisconnection}
+                                                size="small"
+                                                type="link"
+                                            >
+                                                {dictionary.disconnect.toLowerCase()}
+                                            </Button>
+                                            {dictionary.error.fetch.disconnect.end}
                                             <ExternalLink
                                                 className={styles.contactSupport}
                                                 href={`mailto:${dictionary.error.email}`}

--- a/packages/ui/src/components/Widgets/widget.module.scss
+++ b/packages/ui/src/components/Widgets/widget.module.scss
@@ -21,6 +21,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    padding: 0 24px 24px;
   }
 
   .listContent {
@@ -83,4 +84,13 @@
 
 .contactSupport {
   margin-left: 4px;
+
+  :global(.ant-typography) {
+    color: $blue-8 !important;
+  }
+}
+
+.disconnectErrorBtn {
+  padding: 0 4px !important;
+  padding: 0;
 }


### PR DESCRIPTION
# FIX 

- closes #[783](https://d3b.atlassian.net/browse/SJIP-783)

## Description
sers cannot get rid of this error message since there is no disconnect button to clear your tokens in key manager. Therefore, we will add update this sentence in the Connection error message: Please refresh the page or disconnect your account and try again.

“We are currently unable to connect to this service. Please refresh the page or [disconnect](http://test/) your account and try again. If the problem persists, please [contact support](http://test/)”

The disconnect button will act the same as when the user successfully connects (same colors/designs)

Upon clicking the disconnect button, it will bring you back to the Disconnected state of the Cavatica widget and will clear the tokens within key manager.

Other minor adjustments to the widget (follow specs from [les maquettes originales](https://www.figma.com/file/BxMxKt4h6wF4iMWIeC84mg/include-dashboard-v.1.0?type=design&node-id=4-9&mode=design) ):

[les maquettes originales](https://www.figma.com/file/BxMxKt4h6wF4iMWIeC84mg/include-dashboard-v.1.0?type=design&node-id=4-9&mode=design) 

Update to  24px padding. (edited)


## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/88624e69-a8f5-4432-be81-af09cb4ab56e)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/8aa14486-6592-41c3-86be-c2dbd01d9dac)

