### PR TITLE
fix(widget): SJIP-798 fix disconnect btn display

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.12.5 2024-04-11
+- feat: SJIP-797 Fix disconnect button issue
+
 ### 9.12.4 2024-04-11
 - feat: SJIP-791 Fix phenotypes and mondo graph to display empty data
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.12.4",
+    "version": "9.12.5",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Widgets/AuthorizedStudies/index.tsx
+++ b/packages/ui/src/components/Widgets/AuthorizedStudies/index.tsx
@@ -228,7 +228,11 @@ const AuthorizedStudiesWidget = ({
                                         <Text className={styles.notice}>
                                             {dictionary.connectedNotice}
                                             <Button
-                                                className={styles.disconnectBtn}
+                                                className={
+                                                    hasMultipleServices
+                                                        ? styles.manageConnections
+                                                        : styles.disconnectBtn
+                                                }
                                                 icon={<ApiOutlined />}
                                                 loading={authorizedStudies?.loading}
                                                 onClick={() => {

--- a/packages/ui/src/components/Widgets/Cavatica/index.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/index.tsx
@@ -209,7 +209,7 @@ const CavaticaWidget = ({
                                         <Text className={styles.notice}>
                                             {dictionary.connectedNotice}
                                             <Button
-                                                className={styles.disconnectBtn}
+                                                className={styles.manageConnections}
                                                 danger
                                                 icon={<DisconnectOutlined />}
                                                 loading={authentification.loading}

--- a/packages/ui/src/components/Widgets/widget.module.scss
+++ b/packages/ui/src/components/Widgets/widget.module.scss
@@ -4,9 +4,17 @@
   .authenticatedHeader {
     margin-bottom: 8px;
 
-    .disconnectBtn {
+    .manageConnections {
+      margin-left: 8px;
       padding: 0;
       font-size: 12px;
+    }
+
+    .disconnectBtn {
+      margin-left: 8px;
+      padding: 0;
+      font-size: 12px;
+      color: $red-7;
     }
 
     .notice {


### PR DESCRIPTION
# FIX

- closes #[796](https://d3b.atlassian.net/browse/SJIP-796)

## Description
The disconnect button is no longer visible in the Authorized Studies widget once a user is connected.

Open image-20240411-174903.png
image-20240411-174903.png
[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-796)

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/12952771-6b0d-45f6-ad48-fc0054fe1714)

### After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/93986961-894e-43b9-926f-de0db04c41f2)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
