### PR TITLE
feat(cavatica): SJIP-758 add loading state for copy cavatica files

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.14.0 2024-04-17
+- feat: SJIP-758 Add loading state for copy cavatica file
+
 ### 9.13.1 2024-04-17
 - fix: FLUI-130 Adjust some values for the landing page components
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.13.1",
+    "version": "9.14.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.13.1",
+            "version": "9.14.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.13.1",
+    "version": "9.14.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyse.tsx
@@ -213,6 +213,7 @@ const CavaticaAnalyse = ({
 
         if (cavatica.bulkImportData.status === CAVATICA_ANALYSE_STATUS.analyzed) {
             setModalState(ModalState.analyse);
+            return;
         }
     }, [cavatica.bulkImportData.status]);
 

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyzeModal.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaAnalyzeModal.tsx
@@ -4,7 +4,7 @@ import { Button, Divider, List, Modal, ModalFuncProps, Space, Tag, TreeSelect, T
 import { groupBy } from 'lodash';
 import { LegacyDataNode } from 'rc-tree-select/lib/TreeSelect';
 
-import { ICavaticaBulkImportData, ICavaticaProjects } from './type';
+import { CAVATICA_ANALYSE_STATUS, ICavaticaBulkImportData, ICavaticaProjects } from './type';
 
 import styles from './CavaticaAnalyzeModal.module.scss';
 
@@ -115,7 +115,10 @@ const CavaticaAnalyseModal = ({
         <Modal
             className={styles.cavaticaAnalyseModal}
             destroyOnClose
-            okButtonProps={{ disabled: selectedTreeNode === undefined }}
+            okButtonProps={{
+                disabled: selectedTreeNode === undefined,
+                loading: bulkImportData.status === CAVATICA_ANALYSE_STATUS.pending_copy,
+            }}
             okText={dictionary.copyFiles}
             onOk={() => {
                 if (selectedTreeNode) {

--- a/packages/ui/src/components/Widgets/Cavatica/type.ts
+++ b/packages/ui/src/components/Widgets/Cavatica/type.ts
@@ -8,6 +8,8 @@ export enum CAVATICA_ANALYSE_STATUS {
     unauthorize = 'unauthorize_files',
     upload_limit_reached = 'upload_limit_reached',
     pending_analyse = 'pending_analyse',
+    pending_copy = 'pending_copy',
+    copied = 'copied',
     analyzed = 'analyzed',
     unknow = 'unknow',
     generic_error = 'generic_error',

--- a/storybook/stories/Components/Cavatica/Cavatica.stories.tsx
+++ b/storybook/stories/Components/Cavatica/Cavatica.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const CavaticaBasicStory = () => (
     <>
-        <h2>Cavatica with loading</h2>
+        <h2>Cavatica Widget with loading</h2>
         <div style={{width: '400px' }}>
             <CavaticaWidget 
               id={'1'} 
@@ -69,7 +69,7 @@ export const CavaticaBasicStory = () => (
 
 export const CavaticaFetchProjectErrorStory = () => (
     <>
-        <h2>Cavatica with with a failed attemp to fetch project</h2>
+        <h2>Cavatica Widget with with a failed attemp to fetch project</h2>
         <div style={{width: '400px' }}>
             <CavaticaWidget 
               id={'1'} 
@@ -118,7 +118,7 @@ export const CavaticaFetchProjectErrorStory = () => (
 
 export const CavaticaAuthErrorStory = () => (
     <>
-        <h2>Cavatica with authentification error</h2>
+        <h2>Cavatica Widget with authentification error</h2>
         <div style={{width: '400px' }}>
             <CavaticaWidget 
               id={'1'} 


### PR DESCRIPTION
# FEAT

- closes #[758](https://d3b.atlassian.net/browse/SJIP-758)

## Description
 In order to let users know that their operation is in progress, add a loader to the active “copy files” button when copying files to Cavatica

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-758))


## Screenshot

*I slowed down my network and desactivate the modal reset to show the reload state*
[Peek 2024-04-17 13-06.webm](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/4a27a46f-9a45-42ab-84a2-c8dec598908b)

