### PR TITLE
fix(query builder): SJIP-819 add tooltips

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.15.3 2024-05-02
+- fix: SJIP-819 add tooltip to disabled QB Tools buttons
+
 ### 9.15.2 2024-04-30
 - fix: SJIP-803 fix the format of Entity Statistic charts download and previews
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.15.2",
+    "version": "9.15.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.15.2",
+            "version": "9.15.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.15.2",
+    "version": "9.15.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/Header/Tools/index.tsx
+++ b/packages/ui/src/components/QueryBuilder/Header/Tools/index.tsx
@@ -98,7 +98,9 @@ const QueryBuilderHeaderTools = ({
                 </Tooltip>
                 <Tooltip
                     title={
-                        isDirty
+                        isSaveButtonDisabled
+                            ? dictionary.queryBuilderHeader?.tooltips?.saveDisabled || 'Add a query to save'
+                            : isDirty
                             ? dictionary.queryBuilderHeader?.tooltips?.saveChanges || 'Save changes'
                             : dictionary.queryBuilderHeader?.tooltips?.save || 'Save filter'
                     }
@@ -162,7 +164,11 @@ const QueryBuilderHeaderTools = ({
                 </Tooltip>
                 {config.options?.enableShare && (
                     <Tooltip
-                        title={dictionary.queryBuilderHeader?.tooltips?.share || 'Share (Copy url)'}
+                        title={
+                            isNewFilter || isDirty
+                                ? dictionary.queryBuilderHeader?.tooltips?.shareDisabled || 'Save filter to share'
+                                : dictionary.queryBuilderHeader?.tooltips?.share || 'Share (Copy url)'
+                        }
                         {...tooltipAlign}
                     >
                         <Button

--- a/packages/ui/src/components/QueryBuilder/types.ts
+++ b/packages/ui/src/components/QueryBuilder/types.ts
@@ -247,9 +247,11 @@ interface IQueryBuilderHeaderDictionnary {
         newQueryBuilder: React.ReactNode;
         save: React.ReactNode;
         saveChanges: React.ReactNode;
+        saveDisabled: React.ReactNode;
         duplicateQueryBuilder: React.ReactNode;
         delete: React.ReactNode;
         share: React.ReactNode;
+        shareDisabled: React.ReactNode;
         setAsDefaultFilter: React.ReactNode;
         unsetDefaultFilter: React.ReactNode;
         undoChanges: React.ReactNode;


### PR DESCRIPTION
# FIX : Add tooltips to disabled buttons in QB Tools

## Description

[SJIP-819](https://d3b.atlassian.net/browse/SJIP-819)

Acceptance Criterias
- Add tooltips on share and save actions

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="1208" alt="Capture d’écran, le 2024-05-02 à 15 21 05" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/76e1af96-84f6-456e-9e5e-199b07b910c1">

<img width="1208" alt="Capture d’écran, le 2024-05-02 à 15 21 10" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/4e6aa6ac-1eb8-44b6-aa9d-eb439c14fc40">

