### PR TITLE
fix(quick filter): SKFP-1079 click QF from sidebar 

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.16.5 2024-05-27
+- fix: SKFP-1079 open QF from sidebar search click
+
 ### 9.16.4 2024-05-27
 - feat: SKFP-1048 add apply function to QF
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.4",
+    "version": "9.16.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.16.4",
+            "version": "9.16.5",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.4",
+    "version": "9.16.5",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/SidebarMenu/index.tsx
+++ b/packages/ui/src/components/SidebarMenu/index.tsx
@@ -108,7 +108,7 @@ const Sidebar = ({
 
     useEffect(() => {
         if (!collapsed && selectedKey == SEARCH_KEY) {
-            searchInputRef.current?.focus();
+            searchInputRef.current?.input?.click();
         }
     }, [collapsed, selectedKey]);
 


### PR DESCRIPTION
# FIX : open QF from sidebar search click

## Description

[SKFP-1079](https://d3b.atlassian.net/browse/SKFP-1079)

Acceptance Criterias
- if the user click on search icon in Sidebar the QF must be opened

## Screenshot
### Before
see in the ticket
### After
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/3cda2748-1c26-4fd4-8054-6ef9e8e39bf1