### PR TITLE
fix(quick filter): SKFP-1108 SKFP-1109 SKFP-1112

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,8 @@
+### 9.16.14 2024-05-30
+- fix: SKFP-1108 QF clear button style
+- fix: SKFP-1109 QF suggestions max height
+- fix: SKFP-1112 QF none / all actions style
+
 ### 9.16.13 2024-05-28
 - fix: SKFP-1111 QF check all same value
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.13",
+    "version": "9.16.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.16.13",
+            "version": "9.16.14",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.13",
+    "version": "9.16.14",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
@@ -128,7 +128,7 @@ $input-wrapper-prefix: $input-prefix + '-affix-wrapper';
 
 .scrollContent {
     width: 380px;
-    max-height: 250px;
+    max-height: 327px;
     overflow-y: auto;
 }
 

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
@@ -126,9 +126,15 @@ $input-wrapper-prefix: $input-prefix + '-affix-wrapper';
     border-top: 1px solid $gray-4;
 }
 
-.scrollContent {
+.scrollContentLevel1 {
     width: 380px;
     max-height: 327px;
+    overflow-y: auto;
+}
+
+.scrollContentLevel2 {
+    width: 380px;
+    max-height: 286px;
     overflow-y: auto;
 }
 
@@ -181,5 +187,17 @@ $input-wrapper-prefix: $input-prefix + '-affix-wrapper';
             background: transparent;
             text-decoration: none;
         }
+    }
+
+    .checkboxFilterLinks:hover {
+        background: transparent;
+        border: none;
+        color: $checkbox-filter-links-hover;
+        text-decoration: none;
+    }
+
+    .checkboxFilterLinks:focus {
+        background: transparent;
+        border: none;
     }
 }

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.scss
@@ -133,10 +133,7 @@ $input-wrapper-prefix: $input-prefix + '-affix-wrapper';
 }
 
 .clearBtn {
-    color: $gray-8;
-    span {
-        text-decoration: none;
-    }
+    margin-right: 8px;
 }
 
 .applyBtn {

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
@@ -227,7 +227,7 @@ const QuickFilter = ({
                                     )}
                                     <ScrollContent className={styles.scrollContent}>{renderOptions}</ScrollContent>
                                     <div className={styles.popoverFooter}>
-                                        <Button className={styles.clearBtn} onClick={clearFilters} type="link">
+                                        <Button className={styles.clearBtn} onClick={clearFilters} type="text">
                                             {clearLabel}
                                         </Button>
                                         {selectedFacet ? (

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
@@ -225,7 +225,13 @@ const QuickFilter = ({
                                             </Button>
                                         </StackLayout>
                                     )}
-                                    <ScrollContent className={styles.scrollContent}>{renderOptions}</ScrollContent>
+                                    <ScrollContent
+                                        className={
+                                            selectedFacet ? styles.scrollContentLevel2 : styles.scrollContentLevel1
+                                        }
+                                    >
+                                        {renderOptions}
+                                    </ScrollContent>
                                     <div className={styles.popoverFooter}>
                                         <Button className={styles.clearBtn} onClick={clearFilters} type="text">
                                             {clearLabel}


### PR DESCRIPTION
# FIX : Various style fixes

## Description

[SKFP-1108](https://d3b.atlassian.net/browse/SKFP-1108)
[SKFP-1109](https://d3b.atlassian.net/browse/SKFP-1109)
[SKFP-1112](https://d3b.atlassian.net/browse/SKFP-1112)

Acceptance Criterias
- clear style button
- all/none style actions
- suggestion list max height

## Screenshot
### Before

### After

- SKFP-1108
<img width="405" alt="Capture d’écran, le 2024-05-30 à 08 34 23" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/bf19e6e8-0e8f-4d53-b39d-4e835a9d7854">
hover
<img width="405" alt="Capture d’écran, le 2024-05-30 à 08 34 37" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/ba6fda41-ffcf-4208-8b99-029a709feed8">

- SKFP-1109
Level 1
<img width="411" alt="Capture d’écran, le 2024-05-29 à 16 39 50" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/b17a73dc-e29a-48f8-97e3-5d91191a3ecb">
Level 2
<img width="411" alt="Capture d’écran, le 2024-05-30 à 08 26 51" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/a8f78c36-1df9-4e84-a0b2-f4e16d8c8ff5">

- SKFP-1112
<img width="407" alt="Capture d’écran, le 2024-05-30 à 08 36 06" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/c90b0e29-c196-407a-a40a-56eef8521318">
hover
<img width="407" alt="Capture d’écran, le 2024-05-30 à 08 36 12" src="https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/133775440/9395d259-30f2-44be-9702-e228bce35fa4">

