### PR TITLE
Feat/sjip 822/ontology tree port

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.17.0 2024-05-30
+- feat: SJIP-822 Add Ontology Tree Modal component
+
 ### 9.16.14 2024-05-30
 - fix: SKFP-1108 QF clear button style
 - fix: SKFP-1109 QF suggestions max height

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.14",
+    "version": "9.17.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.16.14",
+            "version": "9.17.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -80,6 +80,17 @@
                 "rc-tree-select": "^5.4.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
+            }
+        },
+        "../../../include-portal-ui/node_modules/react": {
+            "version": "18.2.0",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -5069,20 +5080,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -9158,16 +9155,8 @@
             }
         },
         "node_modules/react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "resolved": "../../../include-portal-ui/node_modules/react",
+            "link": true
         },
         "node_modules/react-dom": {
             "version": "18.2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.16.14",
+    "version": "9.17.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTree.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTree.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import OntologyTree, { DEFAULT_ONTOLOGY_TREE_DICTIONARY } from './OntologyTree';
+import { legacyToNewOntologyTreeData } from './utils';
+import { ONTOLOGY_TREE_MOCK_API_RESPONSE } from './utils.test';
+
+const dictionary = DEFAULT_ONTOLOGY_TREE_DICTIONARY;
+
+describe('OntologyTree', () => {
+    test('make sure OntologyTree render correctly', () => {
+        const data = legacyToNewOntologyTreeData(ONTOLOGY_TREE_MOCK_API_RESPONSE);
+        const props = {
+            data,
+            dictionary,
+            setTransferTargetKeys: jest.fn(),
+            total: data.length,
+            transferTargetKeys: [],
+        };
+
+        render(<OntologyTree {...props} />);
+        expect(screen.getByText(dictionary.emptySelection)).toBeTruthy();
+        expect(screen.getByText(`${props.total} unique items`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTree render correctly with empty data', () => {
+        const props = {
+            data: [],
+            dictionary,
+            setTransferTargetKeys: jest.fn(),
+            total: 0,
+            transferTargetKeys: [],
+        };
+
+        render(<OntologyTree {...props} />);
+        expect(screen.getByText(dictionary.emptySelection)).toBeTruthy();
+        expect(screen.getByText(`${props.total} unique items`)).toBeTruthy();
+    });
+});

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTree.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTree.tsx
@@ -1,0 +1,186 @@
+import React, { Key, useState } from 'react';
+import { BranchesOutlined, UserOutlined } from '@ant-design/icons';
+import { Col, Row, Tooltip, Transfer, Tree } from 'antd';
+import { debounce, isEmpty } from 'lodash';
+
+import Empty from '../Empty';
+
+import { IOntologyDataNode, IOntologyTreeData } from './type';
+import {
+    disableNodesInTree,
+    filterTransferTargetKeys,
+    getChildrenKeysByKey,
+    getChildrenKeysByNode,
+    ontologyTreeDataToOntologyDataNode,
+    ontologyTreeToTransferData,
+    searchInOntologyTree,
+} from './utils';
+
+import styles from './index.module.scss';
+
+export const DEFAULT_ONTOLOGY_TREE_DICTIONARY = {
+    emptySelection: 'Select items from the left-hand panel in order to add to your query.',
+    participantsCountTooltip: 'Participants with this exact term',
+    participantsWithExactTermTooltip: 'Participants including descendant terms',
+    searchPlaceholder: 'Search for ontology term  - Min 3 characters',
+    selectedCount: (count: number): string => `${count} unique items`,
+};
+
+const DEBOUNCE_TIMEOUT = 200;
+const MIN_SEARCH_TEXT_LENGTH = 3;
+
+export type TreeNode = {
+    title: string;
+    key: string;
+    hasChildren?: boolean;
+    children: TreeNode[];
+    results?: number;
+    combinedResults?: number;
+    exactTagCount?: number;
+    hidden?: boolean;
+    depth?: number;
+    disabled?: boolean;
+    value?: number;
+    valueText: number;
+    name: React.ReactElement | string;
+};
+
+export type TOntologyTreeDictionary = {
+    participantsCountTooltip?: string;
+    participantsWithExactTermTooltip?: string;
+    searchPlaceholder?: string;
+    emptySelection?: string;
+    selectedCount?: (count: number) => string;
+};
+
+type TOntologyTree = {
+    total: number;
+    data: IOntologyTreeData[];
+    transferTargetKeys: string[];
+    setTransferTargetKeys: (transferTargetKeys: string[]) => void;
+    dictionary?: TOntologyTreeDictionary;
+};
+
+export const OntologyTree = ({
+    data,
+    dictionary = DEFAULT_ONTOLOGY_TREE_DICTIONARY,
+    setTransferTargetKeys,
+    total,
+    transferTargetKeys,
+}: TOntologyTree): JSX.Element => {
+    const defaultTransferData = ontologyTreeToTransferData(data);
+    const defaultTreeData = ontologyTreeDataToOntologyDataNode(data);
+    const [currentTreeData, setCurrentTreeData] = useState<IOntologyDataNode[]>(defaultTreeData);
+    const rootNode = currentTreeData[0];
+    const [treeExpandedKeys, setTreeExpandedKeys] = useState<string[]>(rootNode ? [rootNode.key] : []);
+    const [treeTargetKeys, setTreeTargetKeys] = useState<Key[]>([]);
+    const [transferSelectedCount, setTransferSelectedCount] = useState<number>(total);
+
+    const onSearch = debounce((_, value) => {
+        if (value && value.length >= MIN_SEARCH_TEXT_LENGTH) {
+            const results = searchInOntologyTree(defaultTreeData[0], value);
+            setCurrentTreeData(disableNodesInTree(results.tree[0], treeTargetKeys as string[], transferTargetKeys));
+            setTreeExpandedKeys(results.keys);
+            setTransferSelectedCount(results.selectedCount);
+            return;
+        }
+        setTreeExpandedKeys([rootNode.key]);
+        setCurrentTreeData(disableNodesInTree(defaultTreeData[0], treeTargetKeys as string[], transferTargetKeys));
+        setTransferSelectedCount(total);
+    }, DEBOUNCE_TIMEOUT);
+
+    const onTreeAction = (node: IOntologyDataNode) => {
+        // does the current node is the parent of an already selected node ?
+        const childrenKeys = getChildrenKeysByNode(node);
+        const selectedKeys = [node.key, ...childrenKeys] as Key[];
+        const checked = node.checked
+            ? treeTargetKeys.filter((e) => !selectedKeys.includes(e))
+            : treeTargetKeys.concat(selectedKeys);
+        const updatedTransferTargetKeys = filterTransferTargetKeys(transferTargetKeys, node, childrenKeys);
+
+        setCurrentTreeData(disableNodesInTree(rootNode, checked as string[], updatedTransferTargetKeys));
+        setTreeTargetKeys(checked);
+        setTransferTargetKeys(updatedTransferTargetKeys);
+    };
+
+    return (
+        <Transfer
+            className={styles.transfer}
+            dataSource={defaultTransferData}
+            locale={{
+                notFoundContent: <Empty description={dictionary.emptySelection} imageType="grid" />,
+                searchPlaceholder: dictionary.searchPlaceholder,
+            }}
+            onChange={(newTargetKeys: string[], _, moveKeys: string[]) => {
+                // Since we only allow a single node to be deleted at the time
+                const selectedKeys = [moveKeys[0], ...getChildrenKeysByKey(rootNode, moveKeys[0])] as Key[];
+                setTransferTargetKeys(newTargetKeys);
+                setTreeTargetKeys(treeTargetKeys.filter((e) => !selectedKeys.includes(e)));
+            }}
+            onSearch={onSearch}
+            oneWay
+            operationStyle={{ visibility: 'hidden', width: '5px' }}
+            render={(item) => item.title!}
+            selectAllLabels={[
+                (_) => (
+                    <>
+                        {dictionary.selectedCount
+                            ? dictionary.selectedCount(transferSelectedCount)
+                            : transferSelectedCount}
+                    </>
+                ),
+            ]}
+            showSearch={!isEmpty(defaultTreeData)}
+            showSelectAll={false}
+            targetKeys={transferTargetKeys}
+        >
+            {({ direction }) => {
+                if (direction === 'left') {
+                    if (isEmpty(currentTreeData) || transferSelectedCount === 0) {
+                        return <Empty imageType="grid" />;
+                    }
+
+                    return (
+                        <>
+                            <Row className={styles.treeNodeHeader} justify="space-between">
+                                <Col></Col>
+                                <Col>
+                                    <Row className={styles.treeNodeParticipants}>
+                                        <Col className={styles.treeNodeParticipantsCount} span={12}>
+                                            <Tooltip title={dictionary.participantsWithExactTermTooltip}>
+                                                <UserOutlined />
+                                            </Tooltip>
+                                        </Col>
+                                        <Col className={styles.treeNodeParticipantsCount} span={12}>
+                                            <Tooltip title={dictionary.participantsCountTooltip}>
+                                                <BranchesOutlined />
+                                            </Tooltip>
+                                        </Col>
+                                    </Row>
+                                </Col>
+                            </Row>
+                            <Tree
+                                checkable
+                                checkedKeys={treeTargetKeys}
+                                expandedKeys={treeExpandedKeys}
+                                height={600}
+                                multiple
+                                onCheck={(checked, e) => {
+                                    onTreeAction(e.node);
+                                }}
+                                onExpand={(keys) => setTreeExpandedKeys(keys as string[])}
+                                onSelect={(selected, e) => {
+                                    onTreeAction(e.node);
+                                }}
+                                selectedKeys={[]} // should always be empty
+                                treeData={currentTreeData}
+                            />
+                        </>
+                    );
+                }
+            }}
+        </Transfer>
+    );
+};
+
+export default OntologyTree;

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import OntologyTreeTitle from './OntologyTreeTitle';
+
+describe('OntologyTreeTitle', () => {
+    test('make sure OntologyTreeTitle render correctly', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+        };
+
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654)')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly with a search term', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: ' (HP:0001654)',
+                before: 'Abnormal heart valve ',
+                query: 'morphology',
+                regex: 'morphology',
+                term: 'morphology',
+            },
+        };
+
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve')).toBeTruthy();
+        expect(screen.getByText('morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654)')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+});

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { Col, Row, Tag, Typography } from 'antd';
+
+import { cleanNodeKey, extractCodeAndTitle, HP_CODE, MONDO_CODE } from './utils';
+
+import styles from './index.module.scss';
+
+type TSearchterm = {
+    query: string;
+    regex: string;
+    before: string;
+    term: string;
+    after: string;
+};
+
+type TOntologyTreeTitle = {
+    name: string;
+    participantsWithExactTerm: number;
+    searchTerm?: TSearchterm;
+    participantsCount: number;
+};
+
+export const findOccurenceIndex = (name: string, query: string): number => {
+    let index = name.toLowerCase().indexOf(query.toLowerCase());
+    if (index == -1) {
+        index = cleanNodeKey(name).toLowerCase().indexOf(query.toLowerCase());
+    }
+
+    return index;
+};
+
+const SearchResultTreeTitle = ({ name, query }: { name: string; query: string }) => {
+    const nameLeftParenthesis = name.indexOf('(');
+    const queryLeftParenthesis = query.indexOf('(');
+
+    // from name
+    const firstIndex = findOccurenceIndex(name, query);
+    const lastIndex = firstIndex + query.length;
+    const beforeText = name.substring(0, firstIndex);
+    let termText = name.substring(firstIndex, lastIndex);
+    let afterText = name.substring(lastIndex);
+
+    // Query has parenthesis e.g. "morphology (HP:00"
+    if (queryLeftParenthesis != -1) {
+        const termTextTitle = termText.substring(0, termText.indexOf('('));
+        const termTextCode = termText.substring(termText.indexOf('('));
+        return (
+            <>
+                <Typography.Text>
+                    {beforeText}
+                    <div className={styles.highlight}>{termTextTitle}</div>
+                </Typography.Text>
+                <Typography.Text className={styles.code} type="secondary">
+                    <div className={styles.highlight}>{termTextCode}</div>
+                    {afterText}
+                </Typography.Text>
+            </>
+        );
+    }
+
+    // Query constaint code only e.g. HP:0001654
+    if (query.toLowerCase().startsWith(HP_CODE) || query.toLowerCase().startsWith(MONDO_CODE)) {
+        const termTextTitle = name.substring(0, nameLeftParenthesis);
+        return (
+            <>
+                <Typography.Text>{termTextTitle}</Typography.Text>
+                <Typography.Text className={styles.code} type="secondary">
+                    (<div className={styles.highlight}>{termText}</div>
+                    {afterText}
+                </Typography.Text>
+            </>
+        );
+    }
+
+    // Query has no parenthesis but still contains a code e.g. "morphology HP:00"
+    // Parenthesis must be added to keep the correct style
+    if (lastIndex > nameLeftParenthesis) {
+        termText = name.substring(firstIndex, lastIndex + 1);
+        afterText = afterText.slice(1);
+        const termTextCode = '(' + termText.slice(nameLeftParenthesis - lastIndex);
+        const termTextTitle = termText.slice(0, termText.indexOf('('));
+
+        return (
+            <>
+                <Typography.Text>
+                    {beforeText}
+                    <div className={styles.highlight}>{termTextTitle}</div>
+                </Typography.Text>
+                <Typography.Text className={styles.code} type="secondary">
+                    <div className={styles.highlight}>{termTextCode}</div>
+                    {afterText}
+                </Typography.Text>
+            </>
+        );
+    }
+
+    // Query only contains title term e.g. "morphology"
+    const termTextCode = name.substring(nameLeftParenthesis);
+    afterText = afterText.replace(termTextCode, '');
+    return (
+        <Typography.Text>
+            {beforeText}
+            <div className={styles.highlight}>{termText}</div>
+            {afterText}
+
+            <Typography.Text className={styles.code} type="secondary">
+                {termTextCode}
+            </Typography.Text>
+        </Typography.Text>
+    );
+};
+
+const OntologyTreeTitle = ({
+    name,
+    participantsCount,
+    participantsWithExactTerm,
+    searchTerm,
+}: TOntologyTreeTitle): JSX.Element => {
+    const { code, title } = extractCodeAndTitle(name);
+
+    return (
+        <div className={styles.treeNodeTitle}>
+            <div>
+                {searchTerm ? (
+                    <SearchResultTreeTitle name={name} query={searchTerm.query} />
+                ) : (
+                    <>
+                        {title}
+                        <Typography.Text className={styles.code} type="secondary">
+                            {code}
+                        </Typography.Text>
+                    </>
+                )}
+            </div>
+            <div className={styles.treeNodeParticipants}>
+                <Row>
+                    <Col className={styles.treeNodeParticipantsCount} md={12}>
+                        <Tag>{participantsWithExactTerm}</Tag>
+                    </Col>
+                    <Col className={styles.treeNodeParticipantsCount} md={12}>
+                        <Tag>{participantsCount}</Tag>
+                    </Col>
+                </Row>
+            </div>
+        </div>
+    );
+};
+
+export default OntologyTreeTitle;

--- a/packages/ui/src/components/OntologyTreeFilter/index.module.scss
+++ b/packages/ui/src/components/OntologyTreeFilter/index.module.scss
@@ -1,0 +1,106 @@
+@import "theme.template";
+
+.transfer {
+  div[class$='transfer-list'] {
+    flex: 1 1 50%;
+    width: auto;
+    height: auto;
+    min-height: 600px;
+
+    .highlight {
+      background-color: yellow;
+      display: inherit;
+    }
+
+    div[class$='-list-body-customize-wrapper'] {
+      height: 100%;
+
+      div[class^='ant-spin-'] {
+        height: 100%;
+      }
+    }
+
+    &:last-child {
+      div[class$='-list-body-search-wrapper'] {
+        display: none;
+      }
+    }
+  }
+
+  li[class$='-list-content-item'] {
+    span[class$='-list-content-item-text'] {
+      flex: unset;
+    }
+
+    div[class$='-list-content-item-remove'] {
+      color: $gray-8;
+    }
+  }
+
+  :global(.ant-tree-list-holder-inner) {
+    display: block !important;
+  }
+
+  :global(.ant-tree-treenode) {
+    width: 100%;
+  }
+
+  :global(.ant-tree-node-content-wrapper) {
+    width: 100%;
+    display: block;
+  }
+
+  :global(.ant-tree-title) {
+    display: block;
+    width: 100%;
+  }
+
+  .treeNodeParticipants {
+    min-width: 100px;
+
+    .treeNodeParticipantsCount {
+      display: flex;
+      justify-content: center;
+    }
+  }
+  .treeNodeHeader {
+    padding-right: 4px;
+    margin-bottom: 12px;
+  }
+}
+
+.modalWrapper {
+  min-height: 600px;
+  .modal {
+    width: 90% !important;
+    overflow: hidden;
+  }
+}
+
+.treeNodeTitle {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.code {
+  margin-left: 4px;
+  font-size: 12px;
+}
+
+.loading {
+  display: flex;
+  flex-direction: row;
+  height: 700px;
+  width: 100%;
+
+  :first-child {
+    margin-right: 16px;
+  }
+
+  .skeleton {
+
+    display: flex;
+    width: 100%;
+  }
+}

--- a/packages/ui/src/components/OntologyTreeFilter/index.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/index.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ONTOLOGY_TREE_MOCK_API_RESPONSE } from './utils.test';
+import OntologyTreeModal, { DEFAULT_ONTOLOGY_TREE_MODAL_DICTIONARY } from '.';
+
+const dictionary = DEFAULT_ONTOLOGY_TREE_MODAL_DICTIONARY;
+
+describe('OntologyTreeModal', () => {
+    test('make sure OntologyTreeModal render correctly when closed', () => {
+        const props = {
+            data: [],
+            dictionary,
+            handleCancel: jest.fn(),
+            handleOnApply: jest.fn(),
+            loading: false,
+            open: false,
+        };
+
+        render(<OntologyTreeModal {...props} />);
+        expect(screen.queryByText(dictionary.title)).toBeFalsy();
+        expect(screen.queryByText(dictionary.tree.emptySelection)).toBeFalsy();
+        expect(screen.queryByText('No data')).toBeFalsy();
+    });
+
+    test('make sure OntologyTreeModal render correctly with empty data', () => {
+        const props = {
+            data: [],
+            dictionary,
+            handleCancel: jest.fn(),
+            handleOnApply: jest.fn(),
+            loading: false,
+            open: true,
+        };
+
+        render(<OntologyTreeModal {...props} />);
+        expect(screen.queryByText(dictionary.title)).toBeTruthy();
+        expect(screen.queryByText(dictionary.tree.emptySelection)).toBeFalsy();
+        expect(screen.queryByText('No data')).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeModal render correctly when loading', () => {
+        const props = {
+            data: [],
+            dictionary,
+            handleCancel: jest.fn(),
+            handleOnApply: jest.fn(),
+            loading: true,
+            open: true,
+        };
+
+        render(<OntologyTreeModal {...props} />);
+        expect(screen.queryByText(dictionary.title)).toBeTruthy();
+        expect(screen.queryByText(dictionary.tree.emptySelection)).toBeFalsy();
+        expect(screen.queryByText('No data')).toBeFalsy();
+    });
+
+    test('make sure OntologyTreeModal render correctly with data', () => {
+        const props = {
+            data: ONTOLOGY_TREE_MOCK_API_RESPONSE,
+            dictionary,
+            handleCancel: jest.fn(),
+            handleOnApply: jest.fn(),
+            loading: false,
+            open: true,
+        };
+
+        render(<OntologyTreeModal {...props} />);
+        expect(screen.queryByText(dictionary.title)).toBeTruthy();
+        expect(screen.queryByText(dictionary.tree.emptySelection)).toBeTruthy();
+        expect(screen.queryByText('No data')).toBeFalsy();
+    });
+});

--- a/packages/ui/src/components/OntologyTreeFilter/index.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/index.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Button, Dropdown, Modal, Skeleton, Space, Spin } from 'antd';
+import { isEmpty } from 'lodash';
+import { MenuInfo } from 'rc-menu/lib/interface';
+
+import { TermOperators } from '../../data/sqon/operators';
+import Empty from '../Empty';
+
+import OntologyTree, { DEFAULT_ONTOLOGY_TREE_DICTIONARY, TOntologyTreeDictionary } from './OntologyTree';
+import { ILegacyOntologyTreeData } from './type';
+import { flattenTransferTargetKeys, legacyToNewOntologyTreeData } from './utils';
+
+import styles from './index.module.scss';
+
+export const DEFAULT_ONTOLOGY_TREE_MODAL_DICTIONARY = {
+    allOf: 'All of',
+    anyOf: 'Any of',
+    cancelText: 'Cancel',
+    noneOf: 'None of',
+    okText: 'Apply',
+    title: 'Observed Phenotype (HPO) Browser',
+    tree: DEFAULT_ONTOLOGY_TREE_DICTIONARY,
+};
+
+type TOntologyTreeModalDictionary = {
+    title: string;
+    okText: string;
+    cancelText: string;
+    anyOf: string;
+    allOf: string;
+    noneOf: string;
+    tree: TOntologyTreeDictionary;
+};
+
+type TOntologyTreeFilter = {
+    open: boolean;
+    data: ILegacyOntologyTreeData[];
+    loading: boolean;
+    handleCancel: () => void;
+    handleOnApply: (value: string[], operator: TermOperators) => void;
+    dictionary?: TOntologyTreeModalDictionary;
+};
+
+const OntologyTreeModal = ({
+    data,
+    dictionary = DEFAULT_ONTOLOGY_TREE_MODAL_DICTIONARY,
+    handleCancel,
+    handleOnApply,
+    loading,
+    open,
+}: TOntologyTreeFilter): JSX.Element => {
+    const [transferTargetKeys, setTransferTargetKeys] = useState<string[]>([]);
+    const newOntologyData = legacyToNewOntologyTreeData(data);
+
+    return (
+        <Modal
+            className={styles.modal}
+            footer={[
+                <Space key="tree-modal-actions">
+                    <Button onClick={handleCancel}>{dictionary?.cancelText}</Button>
+                    <Dropdown.Button
+                        menu={{
+                            items: [
+                                {
+                                    key: TermOperators.in,
+                                    label: dictionary.anyOf,
+                                },
+                                {
+                                    key: TermOperators.all,
+                                    label: dictionary.allOf,
+                                },
+                                {
+                                    key: TermOperators['some-not-in'],
+                                    label: dictionary.noneOf,
+                                },
+                            ],
+                            onClick: (e: MenuInfo) =>
+                                handleOnApply(flattenTransferTargetKeys(transferTargetKeys), e.key as TermOperators),
+                        }}
+                        onClick={() => handleOnApply(flattenTransferTargetKeys(transferTargetKeys), TermOperators.in)}
+                        type="primary"
+                    >
+                        {dictionary.okText}
+                    </Dropdown.Button>
+                </Space>,
+            ]}
+            onCancel={handleCancel}
+            open={open}
+            title={dictionary.title}
+            wrapClassName={styles.modalWrapper}
+        >
+            {loading && (
+                <div className={styles.loading}>
+                    <div className={styles.skeleton}>
+                        <Skeleton active paragraph={{ rows: 20 }} title />
+                    </div>
+                    <div className={styles.skeleton}>
+                        <Skeleton active paragraph={{ rows: 20 }} title />
+                    </div>
+                </div>
+            )}
+
+            {!loading && isEmpty(data) && (
+                <div className={styles.loading}>
+                    <Empty imageType="grid" />
+                </div>
+            )}
+
+            {!loading && !isEmpty(data) && (
+                <OntologyTree
+                    data={newOntologyData}
+                    dictionary={dictionary.tree}
+                    setTransferTargetKeys={setTransferTargetKeys}
+                    total={data.length - 1 ?? 0}
+                    transferTargetKeys={transferTargetKeys}
+                />
+            )}
+        </Modal>
+    );
+};
+
+export default OntologyTreeModal;

--- a/packages/ui/src/components/OntologyTreeFilter/type.ts
+++ b/packages/ui/src/components/OntologyTreeFilter/type.ts
@@ -1,0 +1,36 @@
+import { DataNode } from 'antd/lib/tree';
+
+export interface ILegacyOntologyTreeData {
+    key: string;
+    doc_count: number;
+    top_hits: {
+        parents: string[];
+    };
+    filter_by_term: {
+        doc_count: number;
+    };
+}
+
+export interface IOntologyTreeData {
+    key: string;
+    doc_count: number;
+    top_hits: {
+        parents: string[];
+        children: string[];
+    };
+    filter_by_term: {
+        doc_count: number;
+    };
+}
+
+export interface IOntologyDataNode extends Omit<DataNode, 'children' | 'key'> {
+    path: string;
+    key: string;
+    name: string;
+    children: IOntologyDataNode[];
+    checked?: boolean;
+    participantsWithExactTerm: number;
+    participantsCount: number;
+    disabled?: boolean;
+    hasSearchTerm?: boolean;
+}

--- a/packages/ui/src/components/OntologyTreeFilter/utils.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/utils.test.tsx
@@ -1,0 +1,977 @@
+import React from 'react';
+
+import OntologyTreeTitle from './OntologyTreeTitle';
+import {
+    disableNodesInTree,
+    extractCodeAndTitle,
+    filterTransferTargetKeys,
+    flattenTransferTargetKeys,
+    getChildrenKeysByKey,
+    getChildrenKeysByNode,
+    legacyToNewOntologyTreeData,
+    ontologyTreeDataToOntologyDataNode,
+    ontologyTreeToTransferData,
+    searchInOntologyTree,
+} from './utils';
+
+export const ONTOLOGY_TREE_MOCK_API_RESPONSE = [
+    {
+        doc_count: 7175,
+        filter_by_term: {
+            doc_count: 539,
+        },
+        key: 'Phenotypic abnormality (HP:0000118)',
+        top_hits: {
+            parents: ['All (HP:0000001)'],
+        },
+    },
+    {
+        doc_count: 277,
+        filter_by_term: {
+            doc_count: 18,
+        },
+        key: 'Abnormal heart valve morphology (HP:0001654)',
+        top_hits: {
+            parents: ['Abnormal heart morphology (HP:0001627)'],
+        },
+    },
+    {
+        doc_count: 7175,
+        filter_by_term: {
+            doc_count: 0,
+        },
+        key: 'All (HP:0000001)',
+        top_hits: {
+            parents: [],
+        },
+    },
+    {
+        doc_count: 4413,
+        filter_by_term: {
+            doc_count: 308,
+        },
+        key: 'Abnormality of the nervous system (HP:0000707)',
+        top_hits: {
+            parents: ['Phenotypic abnormality (HP:0000118)'],
+        },
+    },
+    {
+        doc_count: 4293,
+        filter_by_term: {
+            doc_count: 253,
+        },
+        key: 'Abnormality of the cardiovascular system (HP:0001626)',
+        top_hits: {
+            parents: ['Phenotypic abnormality (HP:0000118)'],
+        },
+    },
+    {
+        doc_count: 4353,
+        filter_by_term: {
+            doc_count: 0,
+        },
+        key: 'Abnormal nervous system physiology (HP:0012638)',
+        top_hits: {
+            parents: ['Abnormality of the nervous system (HP:0000707)'],
+        },
+    },
+    {
+        doc_count: 3729,
+        filter_by_term: {
+            doc_count: 202,
+        },
+        key: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+        top_hits: {
+            parents: ['Abnormality of the cardiovascular system (HP:0001626)'],
+        },
+    },
+    {
+        doc_count: 3556,
+        filter_by_term: {
+            doc_count: 985,
+        },
+        key: 'Abnormal heart morphology (HP:0001627)',
+        top_hits: {
+            parents: ['Abnormality of cardiovascular system morphology (HP:0030680)'],
+        },
+    },
+];
+
+const LEGACY_ONTOLOGY_TREE_DATA = legacyToNewOntologyTreeData(ONTOLOGY_TREE_MOCK_API_RESPONSE);
+
+describe('OntologyTreeFilter utils', () => {
+    test("legacyToNewOntologyTreeData should correctly convert server's respond", () => {
+        expect(legacyToNewOntologyTreeData(ONTOLOGY_TREE_MOCK_API_RESPONSE)).toEqual([
+            {
+                doc_count: 7175,
+                filter_by_term: {
+                    doc_count: 539,
+                },
+                key: 'Phenotypic abnormality (HP:0000118)',
+                top_hits: {
+                    children: [
+                        'Abnormality of the nervous system (HP:0000707)',
+                        'Abnormality of the cardiovascular system (HP:0001626)',
+                    ],
+                    parents: ['All (HP:0000001)'],
+                },
+            },
+            {
+                doc_count: 277,
+                filter_by_term: {
+                    doc_count: 18,
+                },
+                key: 'Abnormal heart valve morphology (HP:0001654)',
+                top_hits: {
+                    children: [],
+                    parents: ['Abnormal heart morphology (HP:0001627)'],
+                },
+            },
+            {
+                doc_count: 7175,
+                filter_by_term: {
+                    doc_count: 0,
+                },
+                key: 'All (HP:0000001)',
+                top_hits: {
+                    children: ['Phenotypic abnormality (HP:0000118)'],
+                    parents: [],
+                },
+            },
+            {
+                doc_count: 4413,
+                filter_by_term: {
+                    doc_count: 308,
+                },
+                key: 'Abnormality of the nervous system (HP:0000707)',
+                top_hits: {
+                    children: ['Abnormal nervous system physiology (HP:0012638)'],
+                    parents: ['Phenotypic abnormality (HP:0000118)'],
+                },
+            },
+            {
+                doc_count: 4293,
+                filter_by_term: {
+                    doc_count: 253,
+                },
+                key: 'Abnormality of the cardiovascular system (HP:0001626)',
+                top_hits: {
+                    children: ['Abnormality of cardiovascular system morphology (HP:0030680)'],
+                    parents: ['Phenotypic abnormality (HP:0000118)'],
+                },
+            },
+            {
+                doc_count: 4353,
+                filter_by_term: {
+                    doc_count: 0,
+                },
+                key: 'Abnormal nervous system physiology (HP:0012638)',
+                top_hits: {
+                    children: [],
+                    parents: ['Abnormality of the nervous system (HP:0000707)'],
+                },
+            },
+
+            {
+                doc_count: 3729,
+                filter_by_term: {
+                    doc_count: 202,
+                },
+                key: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                top_hits: {
+                    children: ['Abnormal heart morphology (HP:0001627)'],
+                    parents: ['Abnormality of the cardiovascular system (HP:0001626)'],
+                },
+            },
+            {
+                doc_count: 3556,
+                filter_by_term: {
+                    doc_count: 985,
+                },
+                key: 'Abnormal heart morphology (HP:0001627)',
+                top_hits: {
+                    children: ['Abnormal heart valve morphology (HP:0001654)'],
+                    parents: ['Abnormality of cardiovascular system morphology (HP:0030680)'],
+                },
+            },
+        ]);
+    });
+
+    test('ontologyTreeDataToOntologyDataNode should create a antd tree compatible structure', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(ontologyTreeData).toEqual([
+            {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [],
+                                key: 'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707-Abnormal nervous system physiology HP:0012638',
+                                name: 'Abnormal nervous system physiology (HP:0012638)',
+                                participantsCount: 4353,
+                                participantsWithExactTerm: 0,
+                                path: 'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707',
+                                title: (
+                                    <OntologyTreeTitle
+                                        name="Abnormal nervous system physiology (HP:0012638)"
+                                        participantsCount={4353}
+                                        participantsWithExactTerm={0}
+                                    />
+                                ),
+                            },
+                        ],
+                        key: 'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707',
+                        name: 'Abnormality of the nervous system (HP:0000707)',
+                        participantsCount: 4413,
+                        participantsWithExactTerm: 308,
+                        path: 'Phenotypic abnormality HP:0000118',
+                        title: (
+                            <OntologyTreeTitle
+                                name="Abnormality of the nervous system (HP:0000707)"
+                                participantsCount={4413}
+                                participantsWithExactTerm={308}
+                            />
+                        ),
+                    },
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        children: [
+                                            {
+                                                children: [],
+                                                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                participantsCount: 277,
+                                                participantsWithExactTerm: 18,
+                                                path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                title: (
+                                                    <OntologyTreeTitle
+                                                        name="Abnormal heart valve morphology (HP:0001654)"
+                                                        participantsCount={277}
+                                                        participantsWithExactTerm={18}
+                                                    />
+                                                ),
+                                            },
+                                        ],
+                                        key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                        name: 'Abnormal heart morphology (HP:0001627)',
+                                        participantsCount: 3556,
+                                        participantsWithExactTerm: 985,
+                                        path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                        title: (
+                                            <OntologyTreeTitle
+                                                name="Abnormal heart morphology (HP:0001627)"
+                                                participantsCount={3556}
+                                                participantsWithExactTerm={985}
+                                            />
+                                        ),
+                                    },
+                                ],
+                                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                participantsCount: 3729,
+                                participantsWithExactTerm: 202,
+                                path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                title: (
+                                    <OntologyTreeTitle
+                                        name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                        participantsCount={3729}
+                                        participantsWithExactTerm={202}
+                                    />
+                                ),
+                            },
+                        ],
+                        key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                        name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                        participantsCount: 4293,
+                        participantsWithExactTerm: 253,
+                        path: 'Phenotypic abnormality HP:0000118',
+                        title: (
+                            <OntologyTreeTitle
+                                name="Abnormality of the cardiovascular system (HP:0001626)"
+                                participantsCount={4293}
+                                participantsWithExactTerm={253}
+                            />
+                        ),
+                    },
+                ],
+                key: 'Phenotypic abnormality HP:0000118',
+                name: 'Phenotypic abnormality (HP:0000118)',
+                participantsCount: 7175,
+                participantsWithExactTerm: 539,
+                path: '',
+                title: (
+                    <OntologyTreeTitle
+                        name="Phenotypic abnormality (HP:0000118)"
+                        participantsCount={7175}
+                        participantsWithExactTerm={539}
+                    />
+                ),
+            },
+        ]);
+    });
+
+    test('ontologyTreeToTransferData should return a antd transfer compatible array', () => {
+        const transferData = ontologyTreeToTransferData(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(transferData).toEqual([
+            {
+                key: 'Phenotypic abnormality HP:0000118',
+                title: 'Phenotypic abnormality (HP:0000118)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707',
+                title: 'Abnormality of the nervous system (HP:0000707)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707-Abnormal nervous system physiology HP:0012638',
+                title: 'Abnormal nervous system physiology (HP:0012638)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                title: 'Abnormality of the cardiovascular system (HP:0001626)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                title: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                title: 'Abnormal heart morphology (HP:0001627)',
+            },
+            {
+                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                title: 'Abnormal heart valve morphology (HP:0001654)',
+            },
+            {
+                key: 'All (HP:0000001)',
+                title: 'All (HP:0000001)',
+            },
+        ]);
+    });
+
+    test('searchInOntologyTree should return matching keys, selectedCount and a new tree when searching by title', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(searchInOntologyTree(ontologyTreeData[0], 'heart')).toEqual({
+            keys: [
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                'Phenotypic abnormality HP:0000118',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                'Phenotypic abnormality HP:0000118',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                'Phenotypic abnormality HP:0000118',
+            ],
+            selectedCount: 2,
+            tree: [
+                {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            children: [
+                                                {
+                                                    children: [],
+                                                    hasSearchTerm: true,
+                                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                    name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                    participantsCount: 277,
+                                                    participantsWithExactTerm: 18,
+                                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                    title: (
+                                                        <OntologyTreeTitle
+                                                            name="Abnormal heart valve morphology (HP:0001654)"
+                                                            participantsCount={277}
+                                                            participantsWithExactTerm={18}
+                                                            searchTerm={{
+                                                                after: ' valve morphology HP:0001654',
+                                                                before: 'Abnormal ',
+                                                                query: 'heart',
+                                                                regex: 'heart',
+                                                                term: 'heart',
+                                                            }}
+                                                        />
+                                                    ),
+                                                },
+                                            ],
+                                            hasSearchTerm: true,
+                                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                            name: 'Abnormal heart morphology (HP:0001627)',
+                                            participantsCount: 3556,
+                                            participantsWithExactTerm: 985,
+                                            path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                            title: (
+                                                <OntologyTreeTitle
+                                                    name="Abnormal heart morphology (HP:0001627)"
+                                                    participantsCount={3556}
+                                                    participantsWithExactTerm={985}
+                                                    searchTerm={{
+                                                        after: ' morphology HP:0001627',
+                                                        before: 'Abnormal ',
+                                                        query: 'heart',
+                                                        regex: 'heart',
+                                                        term: 'heart',
+                                                    }}
+                                                />
+                                            ),
+                                        },
+                                    ],
+                                    hasSearchTerm: true,
+                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                    name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                    participantsCount: 3729,
+                                    participantsWithExactTerm: 202,
+                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                    title: (
+                                        <OntologyTreeTitle
+                                            name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                            participantsCount={3729}
+                                            participantsWithExactTerm={202}
+                                        />
+                                    ),
+                                },
+                            ],
+                            hasSearchTerm: true,
+                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                            name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                            participantsCount: 4293,
+                            participantsWithExactTerm: 253,
+                            path: 'Phenotypic abnormality HP:0000118',
+                            title: (
+                                <OntologyTreeTitle
+                                    name="Abnormality of the cardiovascular system (HP:0001626)"
+                                    participantsCount={4293}
+                                    participantsWithExactTerm={253}
+                                />
+                            ),
+                        },
+                    ],
+                    key: 'Phenotypic abnormality HP:0000118',
+                    name: 'Phenotypic abnormality (HP:0000118)',
+                    participantsCount: 7175,
+                    participantsWithExactTerm: 539,
+                    path: '',
+                    title: (
+                        <OntologyTreeTitle
+                            name="Phenotypic abnormality (HP:0000118)"
+                            participantsCount={7175}
+                            participantsWithExactTerm={539}
+                        />
+                    ),
+                },
+            ],
+        });
+    });
+
+    test('searchInOntologyTree should return matching keys, selectedCount and a new tree when searching by code', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(searchInOntologyTree(ontologyTreeData[0], 'HP:0001654')).toEqual({
+            keys: [
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                'Phenotypic abnormality HP:0000118',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                'Phenotypic abnormality HP:0000118',
+            ],
+            selectedCount: 1,
+            tree: [
+                {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            children: [
+                                                {
+                                                    children: [],
+                                                    hasSearchTerm: true,
+                                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                    name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                    participantsCount: 277,
+                                                    participantsWithExactTerm: 18,
+                                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                    title: (
+                                                        <OntologyTreeTitle
+                                                            name="Abnormal heart valve morphology (HP:0001654)"
+                                                            participantsCount={277}
+                                                            participantsWithExactTerm={18}
+                                                            searchTerm={{
+                                                                after: '',
+                                                                before: 'Abnormal heart valve morphology ',
+                                                                query: 'HP:0001654',
+                                                                regex: 'HP:0001654',
+                                                                term: 'HP:0001654',
+                                                            }}
+                                                        />
+                                                    ),
+                                                },
+                                            ],
+                                            hasSearchTerm: true,
+                                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                            name: 'Abnormal heart morphology (HP:0001627)',
+                                            participantsCount: 3556,
+                                            participantsWithExactTerm: 985,
+                                            path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                            title: (
+                                                <OntologyTreeTitle
+                                                    name="Abnormal heart morphology (HP:0001627)"
+                                                    participantsCount={3556}
+                                                    participantsWithExactTerm={985}
+                                                />
+                                            ),
+                                        },
+                                    ],
+                                    hasSearchTerm: true,
+                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                    name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                    participantsCount: 3729,
+                                    participantsWithExactTerm: 202,
+                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                    title: (
+                                        <OntologyTreeTitle
+                                            name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                            participantsCount={3729}
+                                            participantsWithExactTerm={202}
+                                        />
+                                    ),
+                                },
+                            ],
+                            hasSearchTerm: true,
+                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                            name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                            participantsCount: 4293,
+                            participantsWithExactTerm: 253,
+                            path: 'Phenotypic abnormality HP:0000118',
+                            title: (
+                                <OntologyTreeTitle
+                                    name="Abnormality of the cardiovascular system (HP:0001626)"
+                                    participantsCount={4293}
+                                    participantsWithExactTerm={253}
+                                />
+                            ),
+                        },
+                    ],
+                    key: 'Phenotypic abnormality HP:0000118',
+                    name: 'Phenotypic abnormality (HP:0000118)',
+                    participantsCount: 7175,
+                    participantsWithExactTerm: 539,
+                    path: '',
+                    title: (
+                        <OntologyTreeTitle
+                            name="Phenotypic abnormality (HP:0000118)"
+                            participantsCount={7175}
+                            participantsWithExactTerm={539}
+                        />
+                    ),
+                },
+            ],
+        });
+    });
+
+    test('searchInOntologyTree should return matching keys, selectedCount and a new tree when searching by title + code', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(searchInOntologyTree(ontologyTreeData[0], 'morphology HP:0001654')).toEqual({
+            keys: [
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                'Phenotypic abnormality HP:0000118',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                'Phenotypic abnormality HP:0000118',
+            ],
+            selectedCount: 1,
+            tree: [
+                {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            children: [
+                                                {
+                                                    children: [],
+                                                    hasSearchTerm: true,
+                                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                    name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                    participantsCount: 277,
+                                                    participantsWithExactTerm: 18,
+                                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                    title: (
+                                                        <OntologyTreeTitle
+                                                            name="Abnormal heart valve morphology (HP:0001654)"
+                                                            participantsCount={277}
+                                                            participantsWithExactTerm={18}
+                                                            searchTerm={{
+                                                                after: '',
+                                                                before: 'Abnormal heart valve ',
+                                                                query: 'morphology HP:0001654',
+                                                                regex: 'morphology\\s*HP:0001654',
+                                                                term: 'morphology HP:0001654',
+                                                            }}
+                                                        />
+                                                    ),
+                                                },
+                                            ],
+                                            hasSearchTerm: true,
+                                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                            name: 'Abnormal heart morphology (HP:0001627)',
+                                            participantsCount: 3556,
+                                            participantsWithExactTerm: 985,
+                                            path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                            title: (
+                                                <OntologyTreeTitle
+                                                    name="Abnormal heart morphology (HP:0001627)"
+                                                    participantsCount={3556}
+                                                    participantsWithExactTerm={985}
+                                                />
+                                            ),
+                                        },
+                                    ],
+                                    hasSearchTerm: true,
+                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                    name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                    participantsCount: 3729,
+                                    participantsWithExactTerm: 202,
+                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                    title: (
+                                        <OntologyTreeTitle
+                                            name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                            participantsCount={3729}
+                                            participantsWithExactTerm={202}
+                                        />
+                                    ),
+                                },
+                            ],
+                            hasSearchTerm: true,
+                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                            name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                            participantsCount: 4293,
+                            participantsWithExactTerm: 253,
+                            path: 'Phenotypic abnormality HP:0000118',
+                            title: (
+                                <OntologyTreeTitle
+                                    name="Abnormality of the cardiovascular system (HP:0001626)"
+                                    participantsCount={4293}
+                                    participantsWithExactTerm={253}
+                                />
+                            ),
+                        },
+                    ],
+                    key: 'Phenotypic abnormality HP:0000118',
+                    name: 'Phenotypic abnormality (HP:0000118)',
+                    participantsCount: 7175,
+                    participantsWithExactTerm: 539,
+                    path: '',
+                    title: (
+                        <OntologyTreeTitle
+                            name="Phenotypic abnormality (HP:0000118)"
+                            participantsCount={7175}
+                            participantsWithExactTerm={539}
+                        />
+                    ),
+                },
+            ],
+        });
+        expect(searchInOntologyTree(ontologyTreeData[0], 'morphology (HP:0001654)')).toEqual({
+            keys: [
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                'Phenotypic abnormality HP:0000118',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                'Phenotypic abnormality HP:0000118',
+            ],
+            selectedCount: 1,
+            tree: [
+                {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            children: [
+                                                {
+                                                    children: [],
+                                                    hasSearchTerm: true,
+                                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                    name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                    participantsCount: 277,
+                                                    participantsWithExactTerm: 18,
+                                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                    title: (
+                                                        <OntologyTreeTitle
+                                                            name="Abnormal heart valve morphology (HP:0001654)"
+                                                            participantsCount={277}
+                                                            participantsWithExactTerm={18}
+                                                            searchTerm={{
+                                                                after: '',
+                                                                before: 'Abnormal heart valve ',
+                                                                query: 'morphology (HP:0001654)',
+                                                                regex: 'morphology\\s*HP:0001654',
+                                                                term: 'morphology HP:0001654',
+                                                            }}
+                                                        />
+                                                    ),
+                                                },
+                                            ],
+                                            hasSearchTerm: true,
+                                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                            name: 'Abnormal heart morphology (HP:0001627)',
+                                            participantsCount: 3556,
+                                            participantsWithExactTerm: 985,
+                                            path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                            title: (
+                                                <OntologyTreeTitle
+                                                    name="Abnormal heart morphology (HP:0001627)"
+                                                    participantsCount={3556}
+                                                    participantsWithExactTerm={985}
+                                                />
+                                            ),
+                                        },
+                                    ],
+                                    hasSearchTerm: true,
+                                    key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                    name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                    participantsCount: 3729,
+                                    participantsWithExactTerm: 202,
+                                    path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                    title: (
+                                        <OntologyTreeTitle
+                                            name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                            participantsCount={3729}
+                                            participantsWithExactTerm={202}
+                                        />
+                                    ),
+                                },
+                            ],
+                            hasSearchTerm: true,
+                            key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                            name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                            participantsCount: 4293,
+                            participantsWithExactTerm: 253,
+                            path: 'Phenotypic abnormality HP:0000118',
+                            title: (
+                                <OntologyTreeTitle
+                                    name="Abnormality of the cardiovascular system (HP:0001626)"
+                                    participantsCount={4293}
+                                    participantsWithExactTerm={253}
+                                />
+                            ),
+                        },
+                    ],
+                    key: 'Phenotypic abnormality HP:0000118',
+                    name: 'Phenotypic abnormality (HP:0000118)',
+                    participantsCount: 7175,
+                    participantsWithExactTerm: 539,
+                    path: '',
+                    title: (
+                        <OntologyTreeTitle
+                            name="Phenotypic abnormality (HP:0000118)"
+                            participantsCount={7175}
+                            participantsWithExactTerm={539}
+                        />
+                    ),
+                },
+            ],
+        });
+    });
+
+    test('searchInOntologyTree should return matching no result found', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        const { keys, selectedCount } = searchInOntologyTree(ontologyTreeData[0], 'no result should be found');
+        expect(keys).toEqual([]);
+        expect(selectedCount).toBe(0);
+    });
+
+    test('disableNodesInTree should disable/enable nodes', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        const treeTargetKeys = [
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+        ];
+        const transferTargetKeys = [
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+        ];
+        const result = searchInOntologyTree(ontologyTreeData[0], 'heart');
+        expect(disableNodesInTree(result.tree[0], treeTargetKeys, transferTargetKeys)).toEqual([
+            {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        children: [
+                                            {
+                                                children: [],
+                                                disableCheckbox: true,
+                                                disabled: true,
+                                                hasSearchTerm: true,
+                                                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+                                                name: 'Abnormal heart valve morphology (HP:0001654)',
+                                                participantsCount: 277,
+                                                participantsWithExactTerm: 18,
+                                                path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                                title: (
+                                                    <OntologyTreeTitle
+                                                        name="Abnormal heart valve morphology (HP:0001654)"
+                                                        participantsCount={277}
+                                                        participantsWithExactTerm={18}
+                                                        searchTerm={{
+                                                            after: ' valve morphology HP:0001654',
+                                                            before: 'Abnormal ',
+                                                            query: 'heart',
+                                                            regex: 'heart',
+                                                            term: 'heart',
+                                                        }}
+                                                    />
+                                                ),
+                                            },
+                                        ],
+                                        disableCheckbox: true,
+                                        disabled: true,
+                                        hasSearchTerm: true,
+                                        key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+                                        name: 'Abnormal heart morphology (HP:0001627)',
+                                        participantsCount: 3556,
+                                        participantsWithExactTerm: 985,
+                                        path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                        title: (
+                                            <OntologyTreeTitle
+                                                name="Abnormal heart morphology (HP:0001627)"
+                                                participantsCount={3556}
+                                                participantsWithExactTerm={985}
+                                                searchTerm={{
+                                                    after: ' morphology HP:0001627',
+                                                    before: 'Abnormal ',
+                                                    query: 'heart',
+                                                    regex: 'heart',
+                                                    term: 'heart',
+                                                }}
+                                            />
+                                        ),
+                                    },
+                                ],
+                                disableCheckbox: false,
+                                disabled: false,
+                                hasSearchTerm: true,
+                                key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+                                name: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+                                participantsCount: 3729,
+                                participantsWithExactTerm: 202,
+                                path: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                                title: (
+                                    <OntologyTreeTitle
+                                        name="Abnormality of cardiovascular system morphology (HP:0030680)"
+                                        participantsCount={3729}
+                                        participantsWithExactTerm={202}
+                                    />
+                                ),
+                            },
+                        ],
+                        disableCheckbox: false,
+                        disabled: false,
+                        hasSearchTerm: true,
+                        key: 'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+                        name: 'Abnormality of the cardiovascular system (HP:0001626)',
+                        participantsCount: 4293,
+                        participantsWithExactTerm: 253,
+                        path: 'Phenotypic abnormality HP:0000118',
+                        title: (
+                            <OntologyTreeTitle
+                                name="Abnormality of the cardiovascular system (HP:0001626)"
+                                participantsCount={4293}
+                                participantsWithExactTerm={253}
+                            />
+                        ),
+                    },
+                ],
+                key: 'Phenotypic abnormality HP:0000118',
+                name: 'Phenotypic abnormality (HP:0000118)',
+                participantsCount: 7175,
+                participantsWithExactTerm: 539,
+                path: '',
+                title: (
+                    <OntologyTreeTitle
+                        name="Phenotypic abnormality (HP:0000118)"
+                        participantsCount={7175}
+                        participantsWithExactTerm={539}
+                    />
+                ),
+            },
+        ]);
+    });
+
+    test('getChildrenKeysByNode should return all children keys related to a node', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(getChildrenKeysByNode(ontologyTreeData[0])).toEqual([
+            'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707',
+            'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707-Abnormal nervous system physiology HP:0012638',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+        ]);
+    });
+
+    test('getChildrenKeysByKey should return all children keys related to node key', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(
+            getChildrenKeysByKey(
+                ontologyTreeData[0],
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+            ),
+        ).toEqual([
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627',
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626-Abnormality of cardiovascular system morphology HP:0030680-Abnormal heart morphology HP:0001627-Abnormal heart valve morphology HP:0001654',
+        ]);
+    });
+
+    test('filterTransferTargetKeys should remove all transferTargetKeys', () => {
+        const ontologyTreeData = ontologyTreeDataToOntologyDataNode(LEGACY_ONTOLOGY_TREE_DATA);
+        expect(
+            filterTransferTargetKeys(
+                ['Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626'],
+                ontologyTreeData[0],
+                [
+                    'Phenotypic abnormality HP:0000118-Abnormality of the nervous system HP:0000707-Abnormal nervous system physiology HP:0012638',
+                ],
+            ),
+        ).toEqual([
+            'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+            'Phenotypic abnormality HP:0000118',
+        ]);
+    });
+
+    test('flattenTransferTargetKeys should convert transfer keys to a search query friendly array', () => {
+        expect(
+            flattenTransferTargetKeys([
+                'Phenotypic abnormality HP:0000118-Abnormality of the cardiovascular system HP:0001626',
+            ]),
+        ).toEqual(['Abnormality of the cardiovascular system HP:0001626']);
+    });
+
+    test('extractCodeAndTitle should extract title and code from a string', () => {
+        expect(extractCodeAndTitle('Phenotypic abnormality (HP:0000118)')).toEqual({
+            code: '(HP:0000118)',
+            title: 'Phenotypic abnormality',
+        });
+
+        expect(extractCodeAndTitle('Phenotypic abnormality (MONDO:0000118)')).toEqual({
+            code: '(MONDO:0000118)',
+            title: 'Phenotypic abnormality',
+        });
+    });
+});

--- a/packages/ui/src/components/OntologyTreeFilter/utils.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/utils.tsx
@@ -1,0 +1,440 @@
+import React from 'react';
+import { TransferItem } from 'antd/lib/transfer';
+
+import OntologyTreeTitle from './OntologyTreeTitle';
+import { ILegacyOntologyTreeData, IOntologyDataNode, IOntologyTreeData } from './type';
+
+export const EXCLUDED_NODES = ['MONDO:0042489', '(HP:0000001)'];
+export const MATCH_SPECIAL_CHARACTERS_REGEX = /[\\^$*+?.()|[\]{}]/g;
+export const TITLE_AND_CODE_REGEX = /^(.+?)\s*(\([Mondo:|HP:][^)]+\))/gi;
+export const HP_CODE = 'hp:';
+export const MONDO_CODE = 'mondo:';
+
+/**
+ * Map server's responsive to contains both parent and child reference
+ * @param data
+ * @returns
+ */
+export const legacyToNewOntologyTreeData = (data: ILegacyOntologyTreeData[]): IOntologyTreeData[] => {
+    const result: IOntologyTreeData[] = [];
+    data.forEach((parent) => {
+        const children: string[] = [];
+        data.forEach((child) => {
+            if (child.top_hits.parents.includes(parent.key)) {
+                children.push(child.key);
+            }
+        });
+
+        result.push({
+            doc_count: parent.doc_count,
+            filter_by_term: parent.filter_by_term,
+            key: parent.key,
+            top_hits: {
+                children,
+                parents: parent.top_hits.parents,
+            },
+        });
+    });
+
+    return result;
+};
+
+/**
+ * Recursive algorithm to create a compatible Tree compatible node list
+ * @param data
+ * @returns
+ */
+export const ontologyTreeDataToOntologyDataNode = (data: IOntologyTreeData[]): IOntologyDataNode[] => {
+    const rootOntologyNode = data.find((node) => node.top_hits.parents.length === 0);
+    if (!rootOntologyNode) {
+        return [];
+    }
+
+    const recursiveNodeCreate = (node: IOntologyTreeData, parentNodePath: string): IOntologyDataNode[] => {
+        const result: IOntologyDataNode[] = [];
+        node.top_hits.children.forEach((key) => {
+            const child = data.find((e) => e.key === key);
+            if (!child) return;
+
+            const participantsCount = child.doc_count ?? 0;
+            const participantsWithExactTerm = child.filter_by_term?.doc_count ?? 0;
+            const nodePath =
+                parentNodePath.length > 0 ? cleanNodeKey(`${parentNodePath}-${child.key}`) : cleanNodeKey(child.key);
+
+            result.push({
+                children: recursiveNodeCreate(child, nodePath),
+                key: nodePath,
+                name: child.key,
+                participantsCount,
+                participantsWithExactTerm,
+                path: parentNodePath ?? '',
+                title: (
+                    <OntologyTreeTitle
+                        name={child.key}
+                        participantsCount={participantsCount}
+                        participantsWithExactTerm={participantsWithExactTerm}
+                    />
+                ),
+            });
+        });
+        return result;
+    };
+
+    const participantsCount = rootOntologyNode.doc_count ?? 0;
+    const participantsWithExactTerm = rootOntologyNode.filter_by_term?.doc_count ?? 0;
+    const rootNode = {
+        children: recursiveNodeCreate(rootOntologyNode, ''),
+        count: rootOntologyNode.filter_by_term?.doc_count,
+        key: rootOntologyNode.key,
+        name: rootOntologyNode.key,
+        participantsCount,
+        participantsWithExactTerm,
+        title: (
+            <OntologyTreeTitle
+                name={rootOntologyNode.key}
+                participantsCount={participantsCount}
+                participantsWithExactTerm={participantsWithExactTerm}
+            />
+        ),
+    };
+    return [...rootNode.children];
+};
+
+/**
+ * Recursive algorithm to create a compatible Transfer compatible item list
+ * @param data
+ * @returns
+ */
+export const ontologyTreeToTransferData = (data: IOntologyTreeData[]): TransferItem[] => {
+    const rootOntologyNode = data.find((node) => node.top_hits.parents.length === 0);
+    if (!rootOntologyNode) {
+        return [];
+    }
+
+    const transferData: TransferItem[] = [];
+
+    const recursive = (node: IOntologyTreeData, parentNodePath: string): IOntologyDataNode[] => {
+        const result: IOntologyDataNode[] = [];
+        node.top_hits.children.forEach((key) => {
+            const child = data.find((e) => e.key === key);
+            if (!child) return;
+            const nodePath =
+                parentNodePath.length > 0 ? cleanNodeKey(`${parentNodePath}-${child.key}`) : cleanNodeKey(child.key);
+
+            // Transfer Data
+            transferData.push({
+                key: nodePath,
+                title: child.key,
+            });
+
+            recursive(child, nodePath);
+        });
+        return result;
+    };
+
+    recursive(rootOntologyNode, '');
+    transferData.push({
+        key: rootOntologyNode.key,
+        title: rootOntologyNode.key,
+    });
+
+    return transferData;
+};
+
+/**
+ * Recursive algorithm in 2 steps
+ * 1. Create an index with all node that has the query in his name
+ * 2. Add parent of those nodes to the result
+ * 3. Remove all unmatching nodes
+ * @param rootNode
+ * @param query
+ * @returns
+ */
+export const searchInOntologyTree = (
+    rootNode: IOntologyDataNode,
+    query: string,
+): {
+    tree: IOntologyDataNode[];
+    keys: string[];
+    selectedCount: number;
+} => {
+    const cleanSearchText = query.replace(MATCH_SPECIAL_CHARACTERS_REGEX, '').replace(/\s+/g, '\\s*');
+    const searchRegex = new RegExp('(\\b\\w*' + cleanSearchText.split(' ').join('\\s*\\w*') + '\\w*\\b)', 'gi');
+    const keys: string[] = [];
+    const tree: IOntologyDataNode[] = [];
+
+    const allNodeKeys: string[] = [];
+    let matchingAll: string[] = [];
+    const matchingNodePaths: string[] = [];
+    const matchingNodes: string[] = [];
+    let matchingExact = 0;
+
+    const recursiveSearch = (node: IOntologyDataNode): IOntologyDataNode[] => {
+        const results: IOntologyDataNode[] = [];
+        allNodeKeys.push(node.key);
+        node.children.forEach((child) => {
+            const hasSearchTerm = child.key.search(searchRegex) >= 0;
+            if (hasSearchTerm) {
+                keys.push(child.key);
+                matchingNodes.push(child.key);
+            }
+
+            results.push({
+                ...child,
+                children: recursiveSearch(child),
+            });
+        });
+
+        return results;
+    };
+
+    const recursiveIndexSearch = (node: IOntologyDataNode): IOntologyDataNode[] => {
+        const results: IOntologyDataNode[] = [];
+        allNodeKeys.push(node.key);
+        node.children.forEach((child) => {
+            const [before, term, after] = cleanNodeKey(child.name).split(searchRegex);
+
+            if (term) {
+                matchingExact += 1;
+            }
+
+            results.push({
+                ...child,
+                children: recursiveIndexSearch(child),
+                hasSearchTerm: matchingAll.includes(child.key),
+                title: (
+                    <OntologyTreeTitle
+                        name={child.name}
+                        participantsCount={child.participantsCount}
+                        participantsWithExactTerm={child.participantsWithExactTerm}
+                        searchTerm={term ? { after, before, query, regex: cleanSearchText, term } : undefined}
+                    />
+                ),
+            });
+        });
+
+        return results.filter((result) => result.hasSearchTerm);
+    };
+
+    // Populate index with matching node
+    recursiveSearch(rootNode);
+
+    // Add all node path to the search results
+    matchingNodes.forEach((nodeKey) => {
+        const nodePaths = nodeKey.split('-');
+        nodePaths.pop();
+        const currentNodePath: string[] = [];
+
+        nodePaths.forEach((path) => {
+            currentNodePath.push(path);
+            const result = allNodeKeys.find((node) => node === currentNodePath.join('-'));
+            if (result) {
+                matchingNodePaths.push(result);
+                keys.push(result);
+            }
+        });
+    });
+
+    // Concat both results
+    matchingAll = matchingNodes.concat(matchingNodePaths);
+
+    if (matchingAll.length === 0) {
+        return {
+            keys: [],
+            selectedCount: 0,
+            tree: [rootNode],
+        };
+    }
+
+    // Update tree with matching index
+    const [before, term, after] = rootNode.name.split(searchRegex);
+    keys.push(rootNode.key);
+    tree.push({
+        ...rootNode,
+        children: recursiveIndexSearch(rootNode),
+        title: (
+            <OntologyTreeTitle
+                name={rootNode.name}
+                participantsCount={rootNode.participantsCount}
+                participantsWithExactTerm={rootNode.participantsWithExactTerm}
+                searchTerm={term ? { after, before, query, regex: cleanSearchText, term } : undefined}
+            />
+        ),
+    });
+
+    return {
+        keys,
+        selectedCount: matchingExact,
+        tree,
+    };
+};
+
+/**
+ * Recursive algorithme that disabled all checked nodes except the one in the transfer component
+ * @param rootNode
+ * @param disabledKeys
+ * @param enabledKeys
+ * @returns
+ */
+export const disableNodesInTree = (
+    rootNode: IOntologyDataNode,
+    disabledKeys: string[],
+    enabledKeys: string[],
+): IOntologyDataNode[] => {
+    if (!rootNode) {
+        return [];
+    }
+
+    const recursive = (node: IOntologyDataNode): IOntologyDataNode[] => {
+        const results: IOntologyDataNode[] = [];
+        node.children.forEach((child) => {
+            if (disabledKeys.includes(child.key) && !enabledKeys.includes(child.key)) {
+                results.push({
+                    ...child,
+                    children: recursive(child),
+                    disableCheckbox: true,
+                    disabled: true,
+                });
+                return;
+            }
+            results.push({
+                ...child,
+                children: recursive(child),
+                disableCheckbox: false,
+                disabled: false,
+            });
+        });
+
+        return results;
+    };
+
+    return [
+        {
+            ...rootNode,
+            children: recursive(rootNode),
+        },
+    ];
+};
+
+/**
+ * To sync both Transfer and Tree, a Recursive algorithm must be used to get all
+ * the child key of node
+ * @param node
+ * @returns
+ */
+export const getChildrenKeysByNode = (node: IOntologyDataNode): string[] => {
+    if (!node) return [];
+    const keys: string[] = [];
+    const recursive = (node: IOntologyDataNode) => {
+        keys.push(node.key);
+
+        node.children.forEach((child) => {
+            recursive(child);
+        });
+    };
+
+    node.children.forEach((child) => {
+        recursive(child);
+    });
+
+    return keys;
+};
+
+/**
+ * When removing a node from a Transfert component, we lost the node's reference. It must found in the
+ * Tree structure to call getChildrenKeysByNode
+ * @param rootNode
+ * @param key
+ * @returns
+ */
+export const getChildrenKeysByKey = (rootNode: IOntologyDataNode, key: string): string[] => {
+    if (rootNode.key === key) {
+        return getChildrenKeysByNode(rootNode);
+    }
+    let targetNode: IOntologyDataNode;
+    let result: string[] = [];
+
+    const recursive = (node: IOntologyDataNode) => {
+        if (node.key === key) {
+            targetNode = node;
+            result = getChildrenKeysByNode(targetNode);
+            return;
+        }
+
+        if (!targetNode && result.length === 0) {
+            node.children.forEach((child) => {
+                recursive(child);
+            });
+        }
+    };
+
+    rootNode.children.forEach((child) => {
+        recursive(child);
+    });
+
+    return result;
+};
+
+/**
+ * Filter transfer keys
+ * @param keys
+ * @param node
+ * @param childrenKeys
+ * @returns
+ */
+export const filterTransferTargetKeys = (keys: string[], node: IOntologyDataNode, childrenKeys: string[]): string[] => {
+    if (keys.includes(node.key)) {
+        return keys.filter((key) => key != node.key);
+    }
+
+    const keysToRemove: string[] = [];
+    keys.forEach((key) => {
+        if (childrenKeys.includes(key)) {
+            keysToRemove.push(key);
+        }
+    });
+
+    return [...keys.filter((key) => !keysToRemove.includes(key)), node.key];
+};
+
+/**
+ * Convert transfert key to a search query friendly array
+ * @param keys
+ * @returns
+ */
+export const flattenTransferTargetKeys = (keys: string[]): string[] => {
+    const result: string[] = [];
+    keys.map((key) => {
+        const phenotype = key.split('-').pop();
+        if (phenotype) {
+            result.push(phenotype);
+        }
+    });
+
+    return result;
+};
+
+/**
+ * Extract title and code
+ * e.g. Abnormal nervous system physiology (HP:0012638)
+ * title: Abnormal nervous system physiology
+ * code: (HP:0012638)
+ * @param value
+ * @returns
+ */
+export const extractCodeAndTitle = (value: string): { code: string; title: string } => {
+    const result = value.split(TITLE_AND_CODE_REGEX).filter((v) => v.length > 0);
+    return {
+        code: result[1],
+        title: result[0],
+    };
+};
+
+/**
+ * Remove special character
+ * e.g. Abnormal nervous system physiology (HP:0012638)
+ * result: Abnormal nervous system physiology HP:0012638
+ * @param key
+ * @returns
+ */
+export const cleanNodeKey = (key: string): string => key.replaceAll(MATCH_SPECIAL_CHARACTERS_REGEX, '');

--- a/packages/ui/src/components/filters/FilterSelector.tsx
+++ b/packages/ui/src/components/filters/FilterSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { CheckboxFilter } from './CheckboxFilter';
+import OntologyTreeModal from '../OntologyTreeFilter';
 import RangeFilter from './RangeFilter';
 import TextInputFilter from './TextInputFilter';
 import ToggleFilter from './ToggleFilter';

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -91,6 +91,7 @@ export enum VisualType {
     Toggle = 'toggle',
     Range = 'range',
     Text = 'text',
+    OntologyTree = 'nested',
 }
 
 export interface IDictionary {

--- a/storybook/stories/Components/OntologyTreeModal/OntologyTreeModal.stories.tsx
+++ b/storybook/stories/Components/OntologyTreeModal/OntologyTreeModal.stories.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import OntologyTreeModal from '@ferlab/ui/core/components/OntologyTreeFilter';
+import { Meta } from '@storybook/react';
+import { TermOperators } from '@ferlab/ui/core/data/sqon/operators';
+
+
+const MOCK_API = [
+    {
+        doc_count: 7175,
+        filter_by_term: {
+            doc_count: 539,
+        },
+        key: 'Phenotypic abnormality (HP:0000118)',
+        top_hits: {
+            parents: ['All (HP:0000001)'],
+        },
+    },
+    {
+        doc_count: 277,
+        filter_by_term: {
+            doc_count: 18,
+        },
+        key: 'Abnormal heart valve morphology (HP:0001654)',
+        top_hits: {
+            parents: ['Abnormal heart morphology (HP:0001627)'],
+        },
+    },
+    {
+        doc_count: 7175,
+        filter_by_term: {
+            doc_count: 0,
+        },
+        key: 'All (HP:0000001)',
+        top_hits: {
+            parents: [],
+        },
+    },
+    {
+        doc_count: 4413,
+        filter_by_term: {
+            doc_count: 308,
+        },
+        key: 'Abnormality of the nervous system (HP:0000707)',
+        top_hits: {
+            parents: ['Phenotypic abnormality (HP:0000118)'],
+        },
+    },
+    {
+        doc_count: 4293,
+        filter_by_term: {
+            doc_count: 253,
+        },
+        key: 'Abnormality of the cardiovascular system (HP:0001626)',
+        top_hits: {
+            parents: ['Phenotypic abnormality (HP:0000118)'],
+        },
+    },
+    {
+        doc_count: 4353,
+        filter_by_term: {
+            doc_count: 0,
+        },
+        key: 'Abnormal nervous system physiology (HP:0012638)',
+        top_hits: {
+            parents: ['Abnormality of the nervous system (HP:0000707)'],
+        },
+    },
+    {
+        doc_count: 3729,
+        filter_by_term: {
+            doc_count: 202,
+        },
+        key: 'Abnormality of cardiovascular system morphology (HP:0030680)',
+        top_hits: {
+            parents: ['Abnormality of the cardiovascular system (HP:0001626)'],
+        },
+    },
+    {
+        doc_count: 3556,
+        filter_by_term: {
+            doc_count: 985,
+        },
+        key: 'Abnormal heart morphology (HP:0001627)',
+        top_hits: {
+            parents: ['Abnormality of cardiovascular system morphology (HP:0030680)'],
+        },
+    },
+];
+
+
+export default {
+    title: '@ferlab/Components/OntologyTreeModal',
+    component: OntologyTreeModal,
+    decorators: [
+        (Story) => (
+            <>
+                <h2>{Story}</h2>
+                <Story />
+            </>
+        ),
+    ],
+} as Meta;
+
+export const OntologyTreeModalStory = () => (
+  <>
+  <h3>OntologyTreeModal Story</h3>
+  <div>
+    <OntologyTreeModal open={true} data={MOCK_API} loading={false} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
+  </div>
+  </>
+)
+
+export const OntologyTreeModalLoadingStory = () => (
+  <>
+  <h3>OntologyTreeModal Loading Story</h3>
+  <div>
+    <OntologyTreeModal open={true} data={[]} loading={true} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
+  </div>
+  </>
+)


### PR DESCRIPTION
# FEAT

- closes #[822](https://d3b.atlassian.net/browse/SJIP-822)

## Description
- Refacto complète du HPO Browser afin d'être côté ferlab. 
- Feat: On ne highlight plus les mots complets mais uniquement la partie concernant la recherche
- Fix: Le count était faux, il affiche maintenant le nombre uniques de phenotypes/diagnoses au lieu du nombre totale de liason
- Fix:La recherche affiche le bon nombre de résultat, wording changé pour unique diagnosis(diagnoses) et unique phenotype(s)
- Feat: On peut désélectionner le noeud courant et sync avec la liste
- Fix: https://d3b.atlassian.net/browse/SJIP-406
- Feat: Changement du loading pour un skeleton
- Feat: Changement du wording pour unique phenotypes ou unique diagnoses

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-822)

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6804ddda-2f33-43fe-b7d9-36b70cda0c8f)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/0b3e095e-0f0c-4fc6-ae51-661e76e9870a)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/21e96645-fc1b-497a-9895-f2d52fb11218)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/11624e20-60bf-4aec-8dbd-8ce10f140ef1)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6c46d73b-cded-4b0f-a423-30c08649f0cb)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/73fba96e-33e3-4ad7-ad32-b82d0127db35)

