### PR TITLE
fix: SKFP-1096 use default link hover color from theme

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.17.1 2024-05-30
+- fix: SKFP-1096 use default link hover color from theme on PopoverLink
+
 ### 9.17.0 2024-05-30
 - feat: SJIP-822 Add Ontology Tree Modal component
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.17.0",
+    "version": "9.17.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.17.0",
+            "version": "9.17.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.17.0",
+    "version": "9.17.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/PopoverContentLink/index.module.scss
+++ b/packages/ui/src/components/PopoverContentLink/index.module.scss
@@ -2,7 +2,4 @@
 
 .popoverContentLink {
   padding: 0;
-  &:hover {
-    color: $body-1;
-  }
 }


### PR DESCRIPTION
# FIX : use default link hover color from theme

- closes [#SKFP-1096](https://d3b.atlassian.net/browse/SKFP-1096)

