### PR TITLE
fix(ontology): SJIP-822 fix issues

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.17.4 2024-06-07
+- fix: SJIP-822 fix ontology tree search, query and css
+
 ### 9.17.3 2024-06-07
 - fix: CLIN-2635 adjust text button styles (add mixins to easily override focus states for QueryBuilder Header)
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.17.3",
+    "version": "9.17.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.17.3",
+            "version": "9.17.4",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.17.3",
+    "version": "9.17.4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTree.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTree.test.tsx
@@ -14,6 +14,23 @@ describe('OntologyTree', () => {
             data,
             dictionary,
             setTransferTargetKeys: jest.fn(),
+            sqonValues: [],
+            total: data.length,
+            transferTargetKeys: [],
+        };
+
+        render(<OntologyTree {...props} />);
+        expect(screen.getByText(dictionary.emptySelection)).toBeTruthy();
+        expect(screen.getByText(`${props.total} unique items`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTree render correctly with sqonValues', () => {
+        const data = legacyToNewOntologyTreeData(ONTOLOGY_TREE_MOCK_API_RESPONSE);
+        const props = {
+            data,
+            dictionary,
+            setTransferTargetKeys: jest.fn(),
+            sqonValues: ['Abnormal heart valve morphology (HP:0001654)'],
             total: data.length,
             transferTargetKeys: [],
         };
@@ -28,6 +45,7 @@ describe('OntologyTree', () => {
             data: [],
             dictionary,
             setTransferTargetKeys: jest.fn(),
+            sqonValues: [],
             total: 0,
             transferTargetKeys: [],
         };

--- a/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/OntologyTreeTitle.test.tsx
@@ -18,7 +18,7 @@ describe('OntologyTreeTitle', () => {
         expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
     });
 
-    test('make sure OntologyTreeTitle render correctly with a search term', () => {
+    test('make sure OntologyTreeTitle render correctly when search by term e.g. "morphology"', () => {
         const props = {
             name: 'Abnormal heart valve morphology (HP:0001654)',
             participantsCount: 200,
@@ -31,11 +31,134 @@ describe('OntologyTreeTitle', () => {
                 term: 'morphology',
             },
         };
-
         render(<OntologyTreeTitle {...props} />);
         expect(screen.getByText('Abnormal heart valve')).toBeTruthy();
         expect(screen.getByText('morphology')).toBeTruthy();
         expect(screen.getByText('(HP:0001654)')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching by code with parenthesis e.g. "(HP:0001654)"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: '',
+                before: 'Abnormal heart valve morphology',
+                query: '(HP:0001654)',
+                regex: 'HP:0001654',
+                term: 'HP:0001654',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654)')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching by code without parenthesis e.g. "HP:0001654"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: ' )',
+                before: 'Abnormal heart valve morphology ',
+                query: 'HP:0001654',
+                regex: 'HP:0001654',
+                term: 'HP:0001654',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve morphology')).toBeTruthy();
+        expect(screen.getByText('HP:0001654')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching by term and code e.g. "morphology (HP:0001654)"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: ' (HP:0001654)',
+                before: 'Abnormal heart valve ',
+                query: 'morphology',
+                regex: 'morphology',
+                term: 'morphology',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve')).toBeTruthy();
+        expect(screen.getByText('morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654)')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching by term and code without parenthesis e.g. "morphology HP:0001654"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: ' ',
+                before: 'Abnormal heart valve ',
+                query: 'morphology HP:0001654',
+                regex: 'morphologys*HP:0001654',
+                term: 'morphology HP:0001654',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve')).toBeTruthy();
+        expect(screen.getByText('morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654')).toBeTruthy();
+        expect(screen.getByText(')')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching by term and code with only the right parenthesis e.g. "morphology HP:0001654)"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: '',
+                before: 'Abnormal heart valve morphology ',
+                query: 'morphology HP:0001654)',
+                regex: 'morphologys*HP:0001654',
+                term: 'morphology HP:0001654',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve')).toBeTruthy();
+        expect(screen.getByText('morphology')).toBeTruthy();
+        expect(screen.getByText('(HP:0001654')).toBeTruthy();
+        expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
+        expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
+    });
+
+    test('make sure OntologyTreeTitle render correctly when searching with a partial code e.g. "000165"', () => {
+        const props = {
+            name: 'Abnormal heart valve morphology (HP:0001654)',
+            participantsCount: 200,
+            participantsWithExactTerm: 100,
+            searchTerm: {
+                after: '',
+                before: 'Abnormal heart valve morphology HP:',
+                query: '000165',
+                regex: '000165',
+                term: '000165',
+            },
+        };
+        render(<OntologyTreeTitle {...props} />);
+        expect(screen.getByText('Abnormal heart valve morphology')).toBeTruthy();
+        expect(screen.getByText('000165')).toBeTruthy();
         expect(screen.getByText(`${props.participantsCount}`)).toBeTruthy();
         expect(screen.getByText(`${props.participantsWithExactTerm}`)).toBeTruthy();
     });

--- a/packages/ui/src/components/OntologyTreeFilter/index.module.scss
+++ b/packages/ui/src/components/OntologyTreeFilter/index.module.scss
@@ -30,6 +30,12 @@
   li[class$='-list-content-item'] {
     span[class$='-list-content-item-text'] {
       flex: unset;
+
+      &:before {
+        content: '';
+        display: block;
+      }
+
     }
 
     div[class$='-list-content-item-remove'] {

--- a/packages/ui/src/components/OntologyTreeFilter/index.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/index.test.tsx
@@ -11,10 +11,31 @@ describe('OntologyTreeModal', () => {
         const props = {
             data: [],
             dictionary,
+            field: 'mondo',
             handleCancel: jest.fn(),
             handleOnApply: jest.fn(),
             loading: false,
             open: false,
+            sqon: {
+                content: [
+                    {
+                        content: {
+                            field: 'mondo.name',
+                            index: 'participant',
+                            remoteComponent: {
+                                id: 'mondoTree',
+                                props: {
+                                    field: 'mondo',
+                                    visible: true,
+                                },
+                            },
+                            value: [],
+                        },
+                        op: 'in',
+                    },
+                ],
+                op: 'and',
+            },
         };
 
         render(<OntologyTreeModal {...props} />);
@@ -27,10 +48,32 @@ describe('OntologyTreeModal', () => {
         const props = {
             data: [],
             dictionary,
+            field: 'mondo',
             handleCancel: jest.fn(),
             handleOnApply: jest.fn(),
             loading: false,
             open: true,
+
+            sqon: {
+                content: [
+                    {
+                        content: {
+                            field: 'mondo.name',
+                            index: 'participant',
+                            remoteComponent: {
+                                id: 'mondoTree',
+                                props: {
+                                    field: 'mondo',
+                                    visible: true,
+                                },
+                            },
+                            value: [],
+                        },
+                        op: 'in',
+                    },
+                ],
+                op: 'and',
+            },
         };
 
         render(<OntologyTreeModal {...props} />);
@@ -43,10 +86,32 @@ describe('OntologyTreeModal', () => {
         const props = {
             data: [],
             dictionary,
+            field: 'mondo',
             handleCancel: jest.fn(),
             handleOnApply: jest.fn(),
             loading: true,
             open: true,
+
+            sqon: {
+                content: [
+                    {
+                        content: {
+                            field: 'mondo.name',
+                            index: 'participant',
+                            remoteComponent: {
+                                id: 'mondoTree',
+                                props: {
+                                    field: 'mondo',
+                                    visible: true,
+                                },
+                            },
+                            value: [],
+                        },
+                        op: 'in',
+                    },
+                ],
+                op: 'and',
+            },
         };
 
         render(<OntologyTreeModal {...props} />);
@@ -59,10 +124,32 @@ describe('OntologyTreeModal', () => {
         const props = {
             data: ONTOLOGY_TREE_MOCK_API_RESPONSE,
             dictionary,
+            field: 'mondo',
             handleCancel: jest.fn(),
             handleOnApply: jest.fn(),
             loading: false,
             open: true,
+
+            sqon: {
+                content: [
+                    {
+                        content: {
+                            field: 'mondo.name',
+                            index: 'participant',
+                            remoteComponent: {
+                                id: 'mondoTree',
+                                props: {
+                                    field: 'mondo',
+                                    visible: true,
+                                },
+                            },
+                            value: [],
+                        },
+                        op: 'in',
+                    },
+                ],
+                op: 'and',
+            },
         };
 
         render(<OntologyTreeModal {...props} />);

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -48,7 +48,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "9.13.0",
+            "version": "9.17.4",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -69,6 +69,7 @@
                 "md5": "^2.3.0",
                 "query-string": "^7.0.1",
                 "react-grid-layout": "^1.4.4",
+                "react-highlight-words": "^0.18.0",
                 "react-icons": "^4.2.0",
                 "react-sizeme": "^3.0.2",
                 "simplebar-react": "^2.4.3",
@@ -88,6 +89,7 @@
                 "@types/md5": "^2.3.2",
                 "@types/react": "^18.2.0",
                 "@types/react-grid-layout": "^1.3.5",
+                "@types/react-highlight-words": "^0.16.4",
                 "@types/uuid": "^8.3.0",
                 "@typescript-eslint/eslint-plugin": "^4.10.0",
                 "@typescript-eslint/parser": "^4.10.0",

--- a/storybook/stories/Components/OntologyTreeModal/OntologyTreeModal.stories.tsx
+++ b/storybook/stories/Components/OntologyTreeModal/OntologyTreeModal.stories.tsx
@@ -1,7 +1,28 @@
 import React from 'react';
 import OntologyTreeModal from '@ferlab/ui/core/components/OntologyTreeFilter';
 import { Meta } from '@storybook/react';
-import { TermOperators } from '@ferlab/ui/core/data/sqon/operators';
+
+
+const sqon = {
+    content: [
+        {
+            content: {
+                field: 'mondo.name',
+                index: 'participant',
+                remoteComponent: {
+                    id: 'mondoTree',
+                    props: {
+                        field: 'mondo',
+                        visible: true,
+                    },
+                },
+                value: [],
+            },
+            op: 'in',
+        },
+    ],
+    op: 'and',
+};
 
 
 const MOCK_API = [
@@ -105,7 +126,7 @@ export const OntologyTreeModalStory = () => (
   <>
   <h3>OntologyTreeModal Story</h3>
   <div>
-    <OntologyTreeModal open={true} data={MOCK_API} loading={false} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
+    <OntologyTreeModal field="observed_phenotype" sqon={sqon} open={true} data={MOCK_API} loading={false} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
   </div>
   </>
 )
@@ -114,7 +135,7 @@ export const OntologyTreeModalLoadingStory = () => (
   <>
   <h3>OntologyTreeModal Loading Story</h3>
   <div>
-    <OntologyTreeModal open={true} data={[]} loading={true} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
+    <OntologyTreeModal field="observed_phenotype" open={true} data={[]} sqon={sqon} loading={true} handleCancel={() => console.log('handleCancel')} handleOnApply={() => console.log('handleOnApply')} />
   </div>
   </>
 )


### PR DESCRIPTION
# FIX | FEAT | REFACTOR | PERF | DOCS : TITLE

- closes #TICKET_NUMBER

## Description

1. Le surlignage de la recherche via le ID est étrange. l’ID s’affiche deux fois et dans la deuxième occurrence, un chiffre de plus est surligné.
Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/d41308d3-c7b0-4bd9-b37f-bc82456bb668)
After
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/5be443ef-aa70-48f3-9025-5c3be06a5fae)

2. Le nombre de participants dans la querybar est toujours 0
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/dbe71261-388e-49cf-8195-a54f3a151bf4)

3. Cliquer sur le premier noeud brise le ontology browser
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1064887b-a2a4-42bd-a181-03d92b971060

4. Retirer le tooltip gris du browser internet
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/ae9465d9-78b9-446c-ae79-edc4e2ba4057)


5. Afficher le ontology browser au clic dans la pilule de la querybar, comme c’était faire avant (ex. de Kids-First dans le vidéo)

https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/b4ffd3c4-af27-4a28-879d-aafac3ec624d


6. Ne pas réafficher la dernière sélection à la réouverture du ontology browser

https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1579f906-7e85-4b21-a36f-063ca039a5cd




