### PR TITLE
fix: clin-2635 fix styles for text-buttons (:focus-visible, :hover, active)

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.19.1 2024-06-13
+- fix: CLIN-2635 adjust text button styles (add mixins to easily override QueryBuilder Header action buttons)
+
 ### 9.19.0 2024-06-13
 - feat: SKFP-1126 add biospecimen requests widget
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.18.2",
+    "version": "9.19.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.18.2",
+            "version": "9.19.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.19.0",
+    "version": "9.19.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/Header/Tools/QueryBuilderHeaderTools.module.scss
+++ b/packages/ui/src/components/QueryBuilder/Header/Tools/QueryBuilderHeaderTools.module.scss
@@ -16,7 +16,7 @@
                     &:not(span) {
                         &:hover,
                         &:focus {
-                            @include query-builder-header-button-dirty-focus
+                            @include query-builder-header-button-dirty-focus;
                         }
                     }
                 }
@@ -24,7 +24,7 @@
                 &:not(span) {
                     &:hover,
                     &:focus-visible {
-                        @include query-builder-header-button-nested-focus-visible
+                        @include query-builder-header-button-nested-focus-visible;
                     }
                 }
             }

--- a/packages/ui/src/components/QueryBuilder/Header/index.module.scss
+++ b/packages/ui/src/components/QueryBuilder/Header/index.module.scss
@@ -25,6 +25,7 @@
     width: 100%;
     white-space: nowrap;
     overflow: hidden;
+    padding: 2px 0;
   }
 }
 
@@ -34,7 +35,7 @@
   width: 100%;
   padding-right: 24px;
 
-  :global(.ant-space-item) {
+  &>:global(.ant-space-item) {
     &:first-child {
       overflow: hidden;
     }
@@ -57,23 +58,7 @@
 
     &.QBHOptionsActionsContainer {
       .iconBtnAction {
-        &:focus,
-        &:hover {
-          background-color: transparent;
-        }
-
-        &:focus-visible {
-          border: 1px solid !important;
-        }
-
-        &:not(:disabled) {
-          color: $query-builder-header-tools-icon-color;
-
-          @include hoverFocus(
-            $query-builder-header-tools-icon-hover,
-            $query-builder-header-tools-icon-focus
-          );
-        }
+        @include query-builder-header-icon-button-action;
       }
 
       .QBHOptionsFavoriteStar {

--- a/packages/ui/themes/default/_mixins.scss
+++ b/packages/ui/themes/default/_mixins.scss
@@ -30,3 +30,24 @@
 @mixin query-builder-header-button-focus-visible {
     border: 1px solid !important;
 }
+
+@mixin query-builder-header-icon-button-action {
+    &:focus,
+    &:hover {
+        background-color: transparent;
+    }
+
+    &:focus-visible {
+        border: 1px solid !important;
+    }
+
+    &:not(:disabled) {
+        color: $query-builder-header-tools-icon-color;
+
+        @include hoverFocus(
+        $query-builder-header-tools-icon-hover,
+        $query-builder-header-tools-icon-focus
+        );
+    }
+}
+


### PR DESCRIPTION
# FIX: CLIN-2635
- Use a mixin to make override easier QueryBuilder action buttons
- Adjust style selector to only match the targeted element

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/CLIN-2635)
