### PR TITLE
feat(queryValue): FLUI-135 use a different separator for operator All Of

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.21.0 2024-06-26
+- fix: FLUI-135 QueryValue: use a different separator for operator All Of
+
 ### 9.20.5 2024-06-21
 - fix: SJIP-822 OntologyTree: improve behavior, fix issue on edit
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.20.4",
+    "version": "9.21.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.20.4",
+            "version": "9.21.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.20.5",
+    "version": "9.21.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/QueryPills/FieldQueryPill.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryPills/FieldQueryPill.tsx
@@ -8,7 +8,6 @@ import { IValueFilter } from '../../../data/sqon/types';
 import { isBooleanFilter, isRangeFilter } from '../../../data/sqon/utils';
 import ConditionalWrapper from '../../utils/ConditionalWrapper';
 import { QueryCommonContext } from '../context';
-import AndOperator from '../icons/AndOperator';
 import ElementOperator from '../icons/ElementOperator';
 import EqualOperator from '../icons/EqualOperator';
 import GreaterThanOperator from '../icons/GreaterThanOperator';

--- a/packages/ui/src/components/QueryBuilder/QueryValues.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryValues.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import take from 'lodash/take';
 
 import { ArrangerValues, keyEnhance } from '../../data/arranger/formatting';
-import { FieldOperators } from '../../data/sqon/operators';
+import { FieldOperators, TermOperators } from '../../data/sqon/operators';
 import { IValueFilter, TFilterValue } from '../../data/sqon/types';
 import { isSet } from '../../data/sqon/utils';
 import { removeUnderscoreAndCapitalize } from '../../utils/stringUtils';
@@ -16,6 +16,9 @@ import UnionOperator from './icons/UnionOperator';
 import { QueryCommonContext } from './context';
 
 import styles from './QueryValues.module.scss';
+
+const COMMA_SEPARATOR = ' , ';
+const AND_SEPARATOR = ' & ';
 
 interface IQueryValuesProps {
     valueFilter: IValueFilter;
@@ -42,11 +45,14 @@ const QueryValues = ({ isElement = false, onClick, valueFilter }: IQueryValuesPr
     };
 
     const getElementOfValueString = (values: TFilterValue) => {
+        const separator = valueFilter.op == TermOperators.all ? AND_SEPARATOR : COMMA_SEPARATOR;
         const hasValueMissing = values.some((val) => val === ArrangerValues.missing);
-        const filteredValues = values.filter((val) => val !== ArrangerValues.missing).join(' , ');
+        const filteredValues = values.filter((val) => val !== ArrangerValues.missing).join(separator);
         const formattedValues = valueFilter.op === FieldOperators.between ? `[${filteredValues}]` : filteredValues;
 
-        return `${formattedValues}${hasValueMissing ? ` , ${getValueName(keyEnhance(ArrangerValues.missing))}` : ''}`;
+        return `${formattedValues}${
+            hasValueMissing ? `${separator}${getValueName(keyEnhance(ArrangerValues.missing))}` : ''
+        }`;
     };
 
     useEffect(() => {


### PR DESCRIPTION
# FEAT

- closes #[135](https://ferlab-crsj.atlassian.net/browse/FLUI-135)

## Description
N’affiche pas le bon signe dans la QueryValue.  Les différentes valeurs devrait être séparer par un & au lieu d’une , lorsque l’opérateur « All of » est utilisé

[JIRA LINK]

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/7fae12ba-f5cb-4b83-9e4e-4512c2182790)


### After
![2024-06-26_10-32](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/5683a5a5-3e76-4729-9864-169f4e86580f)


