### PR TITLE
fix: SKFP-1152 make use of title styling in GridCardHeader

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.21.1 2024-07-02
+- fix: SKFP-1152 Make use of title styling in GridCardHeader
+
 ### 9.21.0 2024-06-26
 - fix: FLUI-135 QueryValue: use a different separator for operator All Of
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.21.0",
+    "version": "9.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.21.0",
+            "version": "9.21.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.21.0",
+    "version": "9.21.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
+++ b/packages/ui/src/view/v2/GridCard/GridCardHeader/index.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, ReactNode, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 import React from 'react';
 import { HolderOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { Popover, PopoverProps, Space, Tooltip, Typography } from 'antd';
@@ -38,7 +38,7 @@ const GridCardHeader = ({
     title,
     titleTruncateThresholdWidth,
     withHandle = false,
-}: OwnProps): JSX.Element => {
+}: OwnProps): ReactElement => {
     const [truncated, setTruncated] = useState(false);
     const [titleWidth, setTitleWidth] = useState('100%');
     const headerContainerRef = useRef() as MutableRefObject<HTMLSpanElement>;
@@ -74,13 +74,14 @@ const GridCardHeader = ({
                     {
                         <div className={styles.titleContainer} style={{ width: titleWidth }}>
                             <Tooltip title={truncated ? title : undefined}>
-                                <Typography.Text
+                                <Title
                                     ellipsis={titleTruncateThresholdWidth ? { onEllipsis: setTruncated } : {}}
-                                    style={{ width: titleWidth }}
+                                    level={4}
+                                    style={{ marginBottom: 0, width: titleWidth }}
                                     tabIndex={0}
                                 >
                                     {title}
-                                </Typography.Text>
+                                </Title>
                             </Tooltip>
                         </div>
                     }


### PR DESCRIPTION
# FIX: make use of title styling in GridCardHeader

- closes [#SKFP-1152](https://d3b.atlassian.net/browse/SKFP-1152)