### PR TITLE
fix(chart): SKFP-1134 adjust bar padding for smaller dataset

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 9.21.4 2024-07-04
+- fix: SKFP-1134 Adjust chart bar width for smaller dataset
+
 ### 9.21.3 2024-07-02
 - fix: SKFP-1152 Change title color in GridCardHeader
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.21.3",
+    "version": "9.21.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "9.21.3",
+            "version": "9.21.4",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "9.21.3",
+    "version": "9.21.4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Bar/index.tsx
+++ b/packages/ui/src/components/Charts/Bar/index.tsx
@@ -13,6 +13,21 @@ type TBarChart = Omit<BarSvgProps<BarDatum>, 'width' | 'height'> & {
 
 const { Title } = Typography;
 
+/**
+ * A padding of 0.1 will make the bar take as much space as needed.
+ * It can result to some wide result with a small set of data.
+ * That why ajust needs for data set that have less than 9 elements
+ * @param length
+ * @returns
+ */
+const getPadding = (length: number): number => {
+    if (length < 9) {
+        return 1 - length / 10;
+    }
+
+    return 0.1;
+};
+
 const BarChart = ({
     colorBy = 'indexValue',
     enableLabel = true,
@@ -54,6 +69,7 @@ const BarChart = ({
                         }
                         e.target.style.cursor = 'pointer';
                     }}
+                    padding={getPadding(rest.data.length)}
                     role="application"
                     valueFormat={valueFormat}
                     {...rest}

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -48,7 +48,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "9.20.1",
+            "version": "9.21.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/storybook/stories/Components/Chart/bar.stories.tsx
+++ b/storybook/stories/Components/Chart/bar.stories.tsx
@@ -2,28 +2,21 @@ import BarChart from '@ferlab/ui/core/components/Charts/Bar';
 import { Meta } from "@storybook/react";
 import React from "react";
 
-const data = [
-    {
-        "id": "1",
-        "label": "label 1",
-        "value": 6560
-    },
-    {
-        "id": "2",
-        "label": "label 2",
-        "value": 2966
-    },
-    {
-        "id": "3",
-        "label": "label 3",
-        "value": 2096
-    },
-    {
-        "id": "4",
-        "label": "label 4",
-        "value": 1681
+
+const getData = (size: number) => {
+    const data = [];
+    for(var i = 0; i < size; i++){
+        data.push({
+            id: i,
+            label: `Label ${i}`,
+            value: Math.floor(Math.random() * 100) + 10
+        })
+
     }
-]
+
+    return data;
+}
+
 
 export default {
     title: "@ferlab/Components/Charts/Bar",
@@ -45,7 +38,7 @@ export const BarChartStory = () => (
         <div style={{width: '600px', height: '600px' }}>
             <BarChart
                 title="Bar Chart Example"
-                data={data}
+                data={getData(4)}
                 margin={{
                     top: 12,
                     bottom: 45,
@@ -63,7 +56,7 @@ export const BarChartWithLegendStory = () => (
         <div style={{marginLeft: '45px', width: '600px', height: '600px' }}>
             <BarChart
                 title="Bar Chart Example"
-                data={data}
+                data={getData(4)}
                 axisLeft={{
                     legend: 'Legend Left',
                     legendPosition: 'middle',
@@ -81,6 +74,86 @@ export const BarChartWithLegendStory = () => (
                     right: 24,
                 }}
             />
+        </div>
+    </>
+);
+
+
+const autoPaddingStyle = {
+    marginLeft: '16px', marginBottom: '32px', width: '100%', height: '600px' 
+}
+export const BarChartAutoPaddingWithLegendStory = () => (
+    <>
+        <h2>Bar chart</h2>
+        <div style={{display: 'flex'}}>
+            {[1, 2, 3, 4, 5].map(size => (
+                    <div style={autoPaddingStyle}>
+                        <BarChart
+                            title="Vertical Bar Chart Example"
+                            data={getData(size)}
+                            margin={{
+                                top: 12,
+                                bottom: 40,
+                                left: 60,
+                                right: 24,
+                            }}
+                        />
+                    </div>
+                )
+            )}
+        </div>
+        <div style={{display: 'flex'}}>
+            {[6, 7, 8, 9, 10].map(size => (
+                    <div style={autoPaddingStyle}>
+                        <BarChart
+                            title="Vertical Bar Chart Example"
+                            data={getData(size)}
+                            margin={{
+                                top: 12,
+                                bottom: 40,
+                                left: 60,
+                                right: 24,
+                            }}
+                        />
+                    </div>
+                )
+            )}
+        </div>
+        <div style={{display: 'flex', marginTop: '24px'}}>
+            {[1, 2, 3, 4, 5].map(size =>  (
+                    <div style={autoPaddingStyle}>
+                        <BarChart
+                            title="Horizontal Bar Chart Example"
+                            data={getData(size)}
+                            layout='horizontal'
+                            margin={{
+                                top: 12,
+                                bottom: 40,
+                                left: 60,
+                                right: 24,
+                            }}
+                        />
+                    </div>
+                )
+            )}
+        </div>
+        <div style={{display: 'flex', marginTop: '24px'}}>
+            {[6, 7, 8, 9, 10].map(size =>  (
+                    <div style={autoPaddingStyle}>
+                        <BarChart
+                            title="Horizontal Bar Chart Example"
+                            data={getData(size)}
+                            layout='horizontal'
+                            margin={{
+                                top: 12,
+                                bottom: 40,
+                                left: 60,
+                                right: 24,
+                            }}
+                        />
+                    </div>
+                )
+            )}
         </div>
     </>
 );


### PR DESCRIPTION
# FIX

- closes #[1134](https://d3b.atlassian.net/browse/SKFP-1134)

## Description
Explore the adjustment to the bar chart parameter that auto-adjusts the parameter width of the Bar charts. To avoid, one very large bar, we will turn off the auto-adjust parameter for the width to maintain the original size based on original # of items in the x-axis. To be done across CQDG, KF, and INCLUDE

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1134)
## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/74b6134c-c05a-4dc4-bd7d-32eb74d9bb6f)

### After
![2024-07-04_08-34](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/36cc2d82-fa92-4639-8944-2345a2a9f04d)
![2024-07-04_08-35_1](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/b3b791ea-b0c3-4b49-b7f3-32e30d2e3509)
![2024-07-04_08-35](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/682b5f8a-0638-4699-abcf-303dee51a1bb)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/6e13bb8f-c108-499b-9191-1672d9c754ab)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/15b4f473-aca8-475c-a51f-88045127d1df)

