### PR TITLE
fix(ontology): SKFP-1172 improve performance for big dataset

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.0.1 2024-07-05
+- fix: SKFP-1172 Improve performance for big datasets
+
 ### 10.0.0 2024-07-03
 - feat: FLUI-132 remove sass, migrate to vanilla css and custom properties 
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.0.0-rc15",
+    "version": "10.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.0.0-rc15",
+            "version": "10.0.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.0.0",
+    "version": "10.0.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/OntologyTreeFilter/utils.test.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/utils.test.tsx
@@ -358,11 +358,6 @@ describe('OntologyTreeFilter utils', () => {
                 'Phenotypic abnormality HP:0000118',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680',
-                'Phenotypic abnormality HP:0000118',
-                'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626',
-                'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680',
-                'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680//Abnormal heart morphology HP:0001627',
-                'Phenotypic abnormality HP:0000118',
             ],
             selectedCount: 2,
             tree: [
@@ -481,7 +476,6 @@ describe('OntologyTreeFilter utils', () => {
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680//Abnormal heart morphology HP:0001627',
-                'Phenotypic abnormality HP:0000118',
             ],
             selectedCount: 1,
             tree: [
@@ -593,7 +587,6 @@ describe('OntologyTreeFilter utils', () => {
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680//Abnormal heart morphology HP:0001627',
-                'Phenotypic abnormality HP:0000118',
             ],
             selectedCount: 1,
             tree: [
@@ -701,7 +694,6 @@ describe('OntologyTreeFilter utils', () => {
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680',
                 'Phenotypic abnormality HP:0000118//Abnormality of the cardiovascular system HP:0001626//Abnormality of cardiovascular system morphology HP:0030680//Abnormal heart morphology HP:0001627',
-                'Phenotypic abnormality HP:0000118',
             ],
             selectedCount: 1,
             tree: [

--- a/packages/ui/src/components/OntologyTreeFilter/utils.tsx
+++ b/packages/ui/src/components/OntologyTreeFilter/utils.tsx
@@ -240,12 +240,16 @@ export const searchInOntologyTree = (
     matchingNodes.forEach((nodeKey) => {
         const nodePaths = nodeKey.split(SEPARATOR);
         nodePaths.pop();
-        const currentNodePath: string[] = [];
+        const currentNodePaths: string[] = [];
 
         nodePaths.forEach((path) => {
-            currentNodePath.push(path);
-            const result = allNodeKeys.find((node) => node === currentNodePath.join(SEPARATOR));
-            if (result) {
+            currentNodePaths.push(path);
+            const nodePath = currentNodePaths.join(SEPARATOR);
+            if (matchingNodePaths.includes(nodePath)) {
+                return;
+            }
+            const result = allNodeKeys.find((node) => node === nodePath);
+            if (result && !matchingNodePaths.includes(result) && !keys.includes(result)) {
                 matchingNodePaths.push(result);
                 keys.push(result);
             }
@@ -265,7 +269,6 @@ export const searchInOntologyTree = (
 
     // Update tree with matching index
     const [before, term, after] = rootNode.name.split(searchRegex);
-    keys.push(rootNode.key);
     tree.push({
         ...rootNode,
         children: recursiveIndexSearch(rootNode),


### PR DESCRIPTION
# FIX

- closes #[1172](https://d3b.atlassian.net/browse/SKFP-1172)

## Description
- Taper « 000 » fait planter l’application. Dans Include, ça ne plante pas. 
- Une recherche va changer pour matching results au lieu de uniques phenotypes (ou diagnoses)

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1172)

## Screenshot
### Before
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/1d6e6cc6-e1bc-4d56-9e60-aeeb5d665651

### After
https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/a12d7975-71b6-4154-90f8-53ea741b0fb3



