### PR TITLE
feat: FLUI-137 publish release enable for ui-v9 branch

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,8 +1,7 @@
 name: Publish Package to npmjs
 on:
   push:
-    branches:
-      - master
+    branches: [ master, ui-v9 ]
 jobs:
   create-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm_release_cadidate.yml
+++ b/.github/workflows/npm_release_cadidate.yml
@@ -1,8 +1,7 @@
 name: Publish Release Candidate Package to npmjs
 on:
   pull_request:
-      branches:
-          - master
+      branches: [ master, ui-v9 ]
 jobs:
   publish-release-candidate-to-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# REFACTOR : publish npm for branch ui-v9

- closes #FLUI-137

## Description

Afin de supporter un retro compatibilité avec la version 9, lorsque un changement doit être sur la version courrante et 9. Nous volons que le script publie sur npm les versions (release, release-candidate)


Critères d’acceptance

lorsque je fais un pull request sur la branch ui-v9 avec une nouvelle version 9.x.x, je dois publier sur npm un  nouvelle ‘release’ sur merge

lorsque je fais un pull request sur la branch ui-v9 avec un nouvelle version. 9.x.x-rcX, je dois publier un nouvelle ‘release-candidate’ on code push

Acceptance Criterias
