### PR TITLE
fix: clin-2868 use a link button to reset assignement filter to be iso with other default filters

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,4 +1,8 @@
 ### 10.0.1 2024-07-05
+- fix: CLIN-2868 use a link button to reset assignement filter to be iso with other default filters
+- fix: CLIN-2868 fix 'more items' button of facets filters style to have the correct width on focus-visible
+
+### 10.0.1 2024-07-05
 - fix: SKFP-1172 Improve performance for big datasets
 
 ### 10.0.0 2024-07-03

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.0.1",
+    "version": "10.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.0.1",
+            "version": "10.1.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.1.0",
+    "version": "10.1.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Assignments/AssignmentsFilter/index.module.css
+++ b/packages/ui/src/components/Assignments/AssignmentsFilter/index.module.css
@@ -23,14 +23,6 @@
   padding: 8px 0 8px 0;
 }
 
-.resetButton {
-  color: var(--blue-8);
-}
-.resetButton:hover {
-  color: var(--blue-8);
-  background-color: var(--gray-3);
-}
-
 .tagContainer {
   height: 24px;
 }

--- a/packages/ui/src/components/Assignments/AssignmentsFilter/index.tsx
+++ b/packages/ui/src/components/Assignments/AssignmentsFilter/index.tsx
@@ -114,7 +114,7 @@ const AssignmentsFilter = ({
                     disabled={selectedOption.length === 0 ? true : false}
                     onClick={() => setSelectedOption([])}
                     size="small"
-                    type="text"
+                    type="link"
                 >
                     {dictionary?.filter?.actions?.reset || 'Reset'}
                 </Button>

--- a/packages/ui/src/components/filters/CheckboxFilter/CheckboxFilter.module.css
+++ b/packages/ui/src/components/filters/CheckboxFilter/CheckboxFilter.module.css
@@ -13,6 +13,7 @@
   height: auto;
   font-size: 12px;
   margin-top: 5px;
+  align-self: flex-start;
 }
 .checkboxFilter .filtersTypesFooter:not(.readOnly) > * {
   text-decoration: underline;


### PR DESCRIPTION
FIX: CLIN-2868 use a link button to reset assignement filter to be iso with other default filters)
- also fix 'more items' button of facets filters style to have the correct width on focus-visible

https://ferlab-crsj.atlassian.net/browse/CLIN-2868

