### PR TITLE
fix(community): SKFP-374 fix roles and interests display

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.4.2 2024-07-23
+- feat: SKFP-374 fix profile roles and interests display
+
 ### 10.4.1 2024-07-23
 - feat: CLIN-2288 display queryPill name in bold (fix font weight)
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.1",
+    "version": "10.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.4.1",
+            "version": "10.4.2",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.1",
+    "version": "10.4.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/CommunityPage/CommunityMemberProfile.test.tsx
+++ b/packages/ui/src/pages/CommunityPage/CommunityMemberProfile.test.tsx
@@ -9,6 +9,40 @@ describe('CommunityMemberProfile', () => {
     test('make sure CommunityMemberProfile render correctly', () => {
         const props = {
             dictionary,
+            options: {
+                interests: [
+                    {
+                        label: 'Adolescent Idiopathic Scoliosis',
+                        value: 'adolescent idiopathic scoliosis',
+                    },
+                    {
+                        label: 'Bladder Exstrophy-Epispadias Complex',
+                        value: 'bladder exstrophy-epispadias complex',
+                    },
+                    {
+                        label: 'Congenital Diaphragmatic Hernia',
+                        value: 'congenital diaphragmatic hernia',
+                    },
+                ],
+                roles: [
+                    {
+                        label: 'Researcher',
+                        value: 'research',
+                    },
+                    {
+                        label: 'Healthcare Professional',
+                        value: 'health',
+                    },
+                    {
+                        label: 'Patient/Family Member',
+                        value: 'patient',
+                    },
+                    {
+                        label: 'Community Member',
+                        value: 'community',
+                    },
+                ],
+            },
             user: {
                 accepted_terms: true,
                 areas_of_interest: ['bladder exstrophy-epispadias complex', 'congenital diaphragmatic hernia'],

--- a/packages/ui/src/pages/CommunityPage/CommunityMemberProfile.tsx
+++ b/packages/ui/src/pages/CommunityPage/CommunityMemberProfile.tsx
@@ -35,13 +35,25 @@ export type TCommunityMemberProfileDictionary = {
     linkedin: string;
 };
 
+type TOption = {
+    label: string;
+    value: string;
+};
+
+export type TCommunityMemberProfileOptions = {
+    roles: TOption[];
+    interests?: TOption[];
+};
+
 export interface ICommunityMemberProfile {
     user?: IUser;
     dictionary?: TCommunityMemberProfileDictionary;
+    options: TCommunityMemberProfileOptions;
 }
 
 export const CommunityMemberProfile = ({
     dictionary = DEFAULT_COMMUNITY_MEMBER_PROFILE_DICTIONARY,
+    options,
     user,
 }: ICommunityMemberProfile): JSX.Element => (
     <Row gutter={[80, 28]}>
@@ -53,14 +65,14 @@ export const CommunityMemberProfile = ({
                         className={cx(styles.infoList, {
                             [styles.empty]: (user?.roles?.length ?? []) === 0,
                         })}
-                        dataSource={user?.roles}
+                        dataSource={options.roles.filter((role) => user?.roles?.includes(role.value))}
                         itemLayout="horizontal"
                         locale={{
                             emptyText: (
                                 <Empty align="left" description={dictionary.roles.noRole} noPadding showImage={false} />
                             ),
                         }}
-                        renderItem={(role, index) => <li key={index}>{role}</li>}
+                        renderItem={(role, index) => <li key={index}>{role.label}</li>}
                     />
                 </Col>
                 {(user?.areas_of_interest ?? []).length > 0 && (
@@ -70,7 +82,9 @@ export const CommunityMemberProfile = ({
                             className={cx(styles.infoList, {
                                 [styles.empty]: (user?.areas_of_interest?.length ?? []) === 0,
                             })}
-                            dataSource={user?.areas_of_interest}
+                            dataSource={(options.interests ?? []).filter((interest) =>
+                                user?.areas_of_interest?.includes(interest.value),
+                            )}
                             itemLayout="horizontal"
                             locale={{
                                 emptyText: (
@@ -82,7 +96,7 @@ export const CommunityMemberProfile = ({
                                     />
                                 ),
                             }}
-                            renderItem={(interest, index) => <li key={index}>{interest}</li>}
+                            renderItem={(interest, index) => <li key={index}>{interest.label}</li>}
                         />
                     </Col>
                 )}

--- a/packages/ui/src/pages/CommunityPage/CommunityMemberProfilePage.test.tsx
+++ b/packages/ui/src/pages/CommunityPage/CommunityMemberProfilePage.test.tsx
@@ -21,6 +21,40 @@ describe('CommunityMemberProfilePage', () => {
             },
             dictionary,
             loading: false,
+            options: {
+                interests: [
+                    {
+                        label: 'Adolescent Idiopathic Scoliosis',
+                        value: 'adolescent idiopathic scoliosis',
+                    },
+                    {
+                        label: 'Bladder Exstrophy-Epispadias Complex',
+                        value: 'bladder exstrophy-epispadias complex',
+                    },
+                    {
+                        label: 'Congenital Diaphragmatic Hernia',
+                        value: 'congenital diaphragmatic hernia',
+                    },
+                ],
+                roles: [
+                    {
+                        label: 'Researcher',
+                        value: 'research',
+                    },
+                    {
+                        label: 'Healthcare Professional',
+                        value: 'health',
+                    },
+                    {
+                        label: 'Patient/Family Member',
+                        value: 'patient',
+                    },
+                    {
+                        label: 'Community Member',
+                        value: 'community',
+                    },
+                ],
+            },
             user: {
                 accepted_terms: true,
                 areas_of_interest: ['bladder exstrophy-epispadias complex', 'congenital diaphragmatic hernia'],

--- a/packages/ui/src/pages/CommunityPage/CommunityMemberProfilePage.tsx
+++ b/packages/ui/src/pages/CommunityPage/CommunityMemberProfilePage.tsx
@@ -11,6 +11,7 @@ import {
     CommunityMemberProfile,
     DEFAULT_COMMUNITY_MEMBER_PROFILE_DICTIONARY,
     TCommunityMemberProfileDictionary,
+    TCommunityMemberProfileOptions,
 } from './CommunityMemberProfile';
 import { IUser } from './type';
 
@@ -26,7 +27,7 @@ export type TCommunityMemberProfilePageDictionary = {
     profile: TCommunityMemberProfileDictionary;
 };
 
-interface ICommunityMemberProfile {
+interface ICommunityMemberProfilePage {
     dictionary?: TCommunityMemberProfilePageDictionary;
     user?: IUser;
     loading: boolean;
@@ -34,6 +35,7 @@ interface ICommunityMemberProfile {
     avatar?: {
         src: string;
     };
+    options: TCommunityMemberProfileOptions;
 }
 
 export const CommunityMemberProfilePage = ({
@@ -41,8 +43,9 @@ export const CommunityMemberProfilePage = ({
     banner,
     dictionary = DEFAULT_COMMUNITY_MEMBER_PROFILE_PAGE_DICTIONARY,
     loading,
+    options,
     user,
-}: ICommunityMemberProfile): JSX.Element => (
+}: ICommunityMemberProfilePage): JSX.Element => (
     <div className={styles.communityMemberWrapper}>
         <div className={styles.communityMember}>
             <CommunityBanner {...banner} dictionary={dictionary.banner} />
@@ -52,7 +55,7 @@ export const CommunityMemberProfilePage = ({
                 {loading ? (
                     <Skeleton active paragraph={{ rows: 6 }} />
                 ) : (
-                    <CommunityMemberProfile dictionary={dictionary.profile} user={user} />
+                    <CommunityMemberProfile dictionary={dictionary.profile} options={options} user={user} />
                 )}
             </div>
         </div>


### PR DESCRIPTION
# FIX 

- closes #[374](https://d3b.atlassian.net/browse/SKFP-374)

## Description
On affiche directement les valeurs de roles et interests, un mapping value/label devrait être utiliser a la place

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-374)



## Screenshot
### Before
![image](https://github.com/user-attachments/assets/82ba9f5b-b9d6-4111-b165-d07fe789b22b)

### After
![image](https://github.com/user-attachments/assets/197f0e4a-8720-43ce-8c48-3ad8397d6a4f)

