### PR TITLE
fix(filter): SKFP-1190 fix apply button alignment

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.4.3 2024-07-24
+- fix: SKFP-1190 fix apply button alignment
+
 ### 10.4.2 2024-07-23
 - feat: SKFP-374 fix profile roles and interests display
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.2",
+    "version": "10.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.4.2",
+            "version": "10.4.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.2",
+    "version": "10.4.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/CheckboxFilter/CheckboxFilter.module.css
+++ b/packages/ui/src/components/filters/CheckboxFilter/CheckboxFilter.module.css
@@ -65,6 +65,7 @@
 .fuiCbfActions > * {
   text-transform: capitalize;
   margin-left: 8px !important;
+  width: auto;
 }
 
 .filterSearchWrapper {


### PR DESCRIPTION
# FIX 
- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SKFP-1190)

## Description
Les boutons “Clear” et “Apply” devraient être à droite.
[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1190)



## Screenshot
### Before
![image](https://github.com/user-attachments/assets/72fb6384-93fb-4e30-b74a-7080d91d08b2)

### After
![image](https://github.com/user-attachments/assets/6015caa0-fe0e-426e-adb3-2e0e138bcc74)


