### PR TITLE
feat: CQDG-830 Pattern for name of Sets and Filters

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,8 +1,8 @@
+### 10.4.6 2024-08-07
+- feat: CQDG-830 add pattern restriction for name of Sets and Filters
+
 ### 10.4.5 2024-08-05
 - feat: FLUI-138 add sentry local storage integration
-
-### 10.4.5 2024-07-24
-- feat: CQDG-830 add pattern restriction for name of Sets and Filters
 
 ### 10.4.4 2024-07-24
 - fix: SKFP-335 fix styles issue for community

--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,6 +1,9 @@
 ### 10.4.5 2024-08-05
 - feat: FLUI-138 add sentry local storage integration
 
+### 10.4.5 2024-07-24
+- feat: CQDG-830 add pattern restriction for name of Sets and Filters
+
 ### 10.4.4 2024-07-24
 - fix: SKFP-335 fix styles issue for community
 
@@ -33,7 +36,7 @@
 - fix: SKFP-1172 Improve performance for big datasets
 
 ### 10.0.0 2024-07-03
-- feat: FLUI-132 remove sass, migrate to vanilla css and custom properties
+- feat: FLUI-132 remove sass, migrate to vanilla css and custom properties 
 
 ### 9.21.4 2024-07-04
 - fix: SKFP-1134 Adjust chart bar width for smaller dataset

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.5",
+    "version": "10.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.4.5",
+            "version": "10.4.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.5",
+    "version": "10.4.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/Header/Tools/EditFilterModal.tsx
+++ b/packages/ui/src/components/QueryBuilder/Header/Tools/EditFilterModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext } from 'react';
 import { WarningFilled } from '@ant-design/icons';
 import { Form, Input, Modal } from 'antd';
+import type { Rule } from 'rc-field-form/lib/interface';
 
 import { QueryBuilderContext, QueryCommonContext } from '../../context';
 
@@ -40,6 +41,34 @@ const EditFilterModal = ({
         [visible],
     );
 
+    const defaultFormRules: Rule[] = [
+        {
+            message: (
+                <span>{dictionary.queryBuilderHeader?.form?.error?.fieldRequired || 'This field is required'}</span>
+            ),
+            required: true,
+            type: 'string',
+        },
+        {
+            max: headerConfig.maxNameCapSavedQuery || DEFAULT_TITLE_MAX_LENGTH,
+            message: (
+                <span>
+                    <WarningFilled /> {headerConfig.maxNameCapSavedQuery || DEFAULT_TITLE_MAX_LENGTH}{' '}
+                    {dictionary.queryBuilderHeader?.modal?.edit?.input.maximumLength || 'characters maximum'}
+                </span>
+            ),
+            required: false,
+            type: 'string',
+        },
+    ];
+
+    const patternFormRule: Rule = {
+        message: dictionary.queryBuilderHeader?.form?.pattern?.message || 'Unauthorized characters',
+        pattern: new RegExp(dictionary.queryBuilderHeader?.form?.pattern?.regex || '', 'ui'),
+        type: 'string',
+        validateTrigger: 'onSubmit',
+    };
+
     return (
         <Modal
             cancelText={dictionary.queryBuilderHeader?.modal?.edit?.cancelText || 'Cancel'}
@@ -76,31 +105,11 @@ const EditFilterModal = ({
                             label={dictionary.queryBuilderHeader?.modal?.edit?.input.label || 'Filter name'}
                             name="title"
                             required={false}
-                            rules={[
-                                {
-                                    message: (
-                                        <span>
-                                            {dictionary.queryBuilderHeader?.form?.error?.fieldRequired ||
-                                                'This field is required'}
-                                        </span>
-                                    ),
-                                    required: true,
-                                    type: 'string',
-                                },
-                                {
-                                    max: headerConfig.maxNameCapSavedQuery || DEFAULT_TITLE_MAX_LENGTH,
-                                    message: (
-                                        <span>
-                                            <WarningFilled />{' '}
-                                            {headerConfig.maxNameCapSavedQuery || DEFAULT_TITLE_MAX_LENGTH}{' '}
-                                            {dictionary.queryBuilderHeader?.modal?.edit?.input.maximumLength ||
-                                                'characters maximum'}
-                                        </span>
-                                    ),
-                                    required: false,
-                                    type: 'string',
-                                },
-                            ]}
+                            rules={
+                                dictionary.queryBuilderHeader?.form?.pattern
+                                    ? [...defaultFormRules, patternFormRule]
+                                    : defaultFormRules
+                            }
                         >
                             <Input
                                 placeholder={

--- a/packages/ui/src/components/QueryBuilder/types.ts
+++ b/packages/ui/src/components/QueryBuilder/types.ts
@@ -236,6 +236,10 @@ interface IQueryBuilderHeaderDictionnary {
         error?: {
             fieldRequired: React.ReactNode;
         };
+        pattern?: {
+            regex: RegExp;
+            message: string;
+        };
     };
     notification?: {
         savedTitle: React.ReactNode;

--- a/storybook/stories/Components/QueryBuilder/QueryBuilder.stories.tsx
+++ b/storybook/stories/Components/QueryBuilder/QueryBuilder.stories.tsx
@@ -590,6 +590,80 @@ WithHeaderAndTools.args = {
     IconTotal: <MdPeople />,
 };
 
+/* with header and tools and pattern */
+export const WithHeaderAndToolsAndPattern = QueryBuilderStory.bind({});
+const withHeaderAndToolsAndPatternQbID = QB_ID + 'WithHeaderAndToolsAndPattern';
+setQueryBuilderState(withHeaderAndToolsAndPatternQbID, {
+    state: [
+        {
+            op: 'and',
+            content: [
+                {
+                    content: {
+                        value: ['something'],
+                        field: 'test',
+                    },
+                    op: 'in',
+                },
+            ],
+            total: 1500,
+            id: '1',
+        },
+    ],
+    active: '1',
+});
+WithHeaderAndToolsAndPattern.args = {
+    id: withHeaderAndToolsAndPatternQbID,
+    title: 'With header, tools and pattern (Can\'t use $ in the filter name)',
+    getResolvedQueryForCount: defaultResolveCountPromise,
+    fetchQueryCount: defaultFetchQuerCount,
+    headerConfig: {
+        showHeader: true,
+        showTools: true,
+        defaultTitle: 'Untitled Query',
+        options: {
+            enableDuplicate: true,
+            enableEditTitle: true,
+            enableShare: true,
+            enableUndoChanges: true,
+        },
+        savedFilters: [
+            {
+                title: 'My query',
+                op: 'and',
+                content: [
+                    {
+                        content: {
+                            value: ['something'],
+                            field: 'test',
+                            op: 'in',
+                        },
+                    },
+                ],
+                total: 1500,
+                id: '1',
+                updated_date: '2022-09-23T03:02:01.286Z',
+            },
+        ],
+        onSaveQuery: (filter: any) => {},
+        onDuplicateQuery: (filter: any) => {},
+        onDeleteQuery: (filter: any) => {},
+    },
+    dictionary: {
+        queryBuilderHeader: {
+            form: {
+                pattern: {
+                    message: "Can't use $",
+                    regex: '^.[^$]+$',
+                }
+            }
+        }
+    },
+    onRemoveFacet: (f: any) => f,
+    onChangeQuery: (f: any) => f,
+    IconTotal: <MdPeople />,
+};
+
 /* with name mapping */
 export const WithNameMapping = QueryBuilderStory.bind({});
 const withNameMappingQbId = QB_ID + 'WithNameMapping';


### PR DESCRIPTION
# FEAT: Filters restricting characters

- closes [CQDG-830](https://ferlab-crsj.atlassian.net/browse/CQDG-830)

## Description

The backend (Users-api) is restricting some characters when naming Sets and Filters. Front-end should do the same. User has no idea why saving the Set or Filter fails at the moment.   

[JIRA LINK](CQDG-830)


## Screenshot
![Screenshot from 2024-08-06 14-37-21](https://github.com/user-attachments/assets/f17be7b6-cb27-4f45-bb96-0579a1407203)

![Screenshot from 2024-08-06 15-00-13](https://github.com/user-attachments/assets/d552d96d-cdb7-4ee4-8233-c12200421233)



Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo


[CQDG-830]: https://ferlab-crsj.atlassian.net/browse/CQDG-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ