### PR TITLE
feat(description): add basic-bordered theme for variant entity summary

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.5.0 2024-08-12
+- feat: FLUI-131 add basic-bordered theme for description
+
 ### 10.4.6 2024-08-07
 - feat: CQDG-830 add pattern restriction for name of Sets and Filters
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.6",
+    "version": "10.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.4.6",
+            "version": "10.5.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.4.6",
+    "version": "10.5.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.module.css
+++ b/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.module.css
@@ -95,6 +95,32 @@
   margin-bottom: 12px;
 }
 
+.leftSection {
+  display: flex;
+}
+
+.leftSection :global(.ant-descriptions):first-child {
+  margin-right: 12px;
+}
+
+.leftSection :global(.ant-descriptions):last-child {
+  margin-left: 12px;
+}
+
+.basicBordered {
+  width: 100%;
+}
+
+.basicBordered :global(.ant-descriptions-view) {
+  border: none;
+}
+
+.basicBordered :global(.ant-descriptions-item-label) {
+  background: none;
+  border-right: none;
+  padding: 4px 0 !important;
+}
+
 @media (max-width: 1024px) {
   .bannerWrapper {
     grid-template-columns: repeat(3, 1fr);

--- a/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
-import { Card, Descriptions, Space, Typography } from 'antd';
+import { Card, Descriptions, DescriptionsProps, Space, Typography } from 'antd';
+import cx from 'classnames';
 
 import Empty from '../../../components/Empty';
 
@@ -27,14 +28,42 @@ export interface IVariantSummaryData {
     };
 }
 
+type TTheme = 'basic' | 'basic-bordered';
+
 export interface ISummaryProps {
     id: string;
     loading: boolean;
     noDataLabel: string;
     data?: IVariantSummaryData;
+    theme?: TTheme;
 }
 
-export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummaryProps): JSX.Element => {
+const getDescriptionPropsBasedOnTheme = (theme: TTheme): DescriptionsProps => {
+    let props: DescriptionsProps = {};
+    switch (theme) {
+        case 'basic-bordered':
+            props = {
+                bordered: true,
+                className: style.basicBordered,
+            };
+            break;
+        default:
+            props = {
+                bordered: false,
+            };
+            break;
+    }
+
+    return props;
+};
+
+export const EntityVariantSummary = ({
+    data,
+    id,
+    loading,
+    noDataLabel,
+    theme = 'basic',
+}: ISummaryProps): JSX.Element => {
     let detailsLeftSectionLength = data?.details.leftSection.items.length || 0;
     if (detailsLeftSectionLength % 2 != 0) detailsLeftSectionLength++;
     const detailsLeftSectionCol1 = data?.details.leftSection.items.slice(0, detailsLeftSectionLength / 2);
@@ -42,6 +71,7 @@ export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummar
         detailsLeftSectionLength / 2,
         detailsLeftSectionLength,
     );
+    const descriptionProps = getDescriptionPropsBasedOnTheme(theme);
 
     return (
         <div className={style.summaryWrapper} id={id}>
@@ -73,8 +103,8 @@ export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummar
                             <div className={style.detailsWrapper}>
                                 <div className={style.score}>
                                     <div className={style.detailsTitle}>{data.details.leftSection.title}</div>
-                                    <Space align="start" direction="horizontal" size="middle">
-                                        <Descriptions column={1}>
+                                    <div className={style.leftSection}>
+                                        <Descriptions {...descriptionProps} column={1}>
                                             {detailsLeftSectionCol1?.map((item: IDataItem, index: number) => (
                                                 <Descriptions.Item
                                                     key={index}
@@ -84,7 +114,7 @@ export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummar
                                                 </Descriptions.Item>
                                             ))}
                                         </Descriptions>
-                                        <Descriptions column={1}>
+                                        <Descriptions {...descriptionProps} column={1}>
                                             {detailsLeftSectionCol2?.map((item: IDataItem, index: number) => (
                                                 <Descriptions.Item
                                                     key={index}
@@ -94,12 +124,15 @@ export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummar
                                                 </Descriptions.Item>
                                             ))}
                                         </Descriptions>
-                                    </Space>
+                                    </div>
                                 </div>
                                 <div className={style.geneSplice}>
                                     {data.details.middleSection.map((detail: IDetailData, index: number) => (
                                         <Descriptions
-                                            className={style.detailsItem}
+                                            {...descriptionProps}
+                                            className={cx(style.detailsItem, {
+                                                [style.basicBordered]: theme === 'basic-bordered',
+                                            })}
                                             column={1}
                                             key={index}
                                             title={<span className={style.detailsTitle}>{detail.title}</span>}
@@ -117,6 +150,7 @@ export const EntityVariantSummary = ({ data, id, loading, noDataLabel }: ISummar
                                 </div>
                                 <div className={style.omim}>
                                     <Descriptions
+                                        {...descriptionProps}
                                         column={1}
                                         title={
                                             <span className={style.detailsTitle}>

--- a/storybook/stories/Pages/EntityPage/EntityVariantSummary.stories.tsx
+++ b/storybook/stories/Pages/EntityPage/EntityVariantSummary.stories.tsx
@@ -72,3 +72,56 @@ BasicEntityVariantSummary.args = {
         },
     },
 };
+
+
+export const BorderedEntityVariantSummary = EntityVariantSummaryStory.bind({});
+BorderedEntityVariantSummary.args = {
+    id: 'ID',
+    loading: false,
+    noDataLabel: 'No data available',
+    data: {
+        banner: [
+            { label: 'Item 1', value: 'Value 1' },
+            { label: 'Item 2', value: 'Value 2' },
+            { label: 'Item 3', value: 'Value 3' },
+            { label: 'Item 4', value: 'Value 4' },
+            { label: 'Item 5', value: 'Value 5' },
+        ],
+        info: ['Item 1', 'Item 2', 'Item 3', 'Item 4'],
+        details: {
+            leftSection: {
+                title: 'Block 1',
+                items: [
+                    { label: 'Item 1', value: 'Value 1' },
+                    { label: 'Item 2', value: 'Value 2' },
+                    { label: 'Item 3', value: 'Value 3' },
+                    { label: 'Item 4', value: 'Value 4' },
+                    { label: 'Item 5', value: 'Value 5' },
+                    { label: 'Item 6', value: 'Value 6' },
+                ],
+            },
+            middleSection: [
+                {
+                    title: 'Block 2.1',
+                    items: [
+                        { label: 'Item 1', value: 'Value 1' },
+                        { label: 'Item 2', value: 'Value 2' },
+                    ],
+                },
+                {
+                    title: 'Block 2.2',
+                    items: [{ label: 'Item 1', value: 'Value 1' }],
+                },
+            ],
+            rightSection: {
+                title: 'Block 3',
+                items: [
+                    { label: 'Item 1', value: 'Value 1' },
+                    { label: 'Item 2', value: 'Value 2' },
+                    { label: 'Item 3', value: 'Value 3' },
+                ],
+            },
+        },
+    },
+    theme: 'basic-bordered'
+};


### PR DESCRIPTION
# FEAT

- closes #[131](https://ferlab-crsj.atlassian.net/browse/FLUI-131)

## Description
Add a new border property to the Descriptions Basic component (see [this FerLab ticket](https://ferlab-crsj.atlassian.net/browse/FLUI-131))

[[JIRA LINK]](https://ferlab-crsj.atlassian.net/browse/FLUI-131)

## Screenshot
![image](https://github.com/user-attachments/assets/bb13c77d-ef24-4701-9c10-4fa46497cd8b)

![image](https://github.com/user-attachments/assets/1affa6ca-4969-42e1-bba4-bcaa35c5a37a)

