### PR TITLE
fix(FLUI-131): fix basic-bordered theme for description

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.5.1 2024-08-14
+- fix: FLUI-131 fix basic-bordered theme for description
+
 ### 10.5.0 2024-08-12
 - feat: FLUI-131 add basic-bordered theme for description
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.5.0",
+    "version": "10.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.5.0",
+            "version": "10.5.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.5.0",
+    "version": "10.5.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.module.css
+++ b/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.module.css
@@ -112,13 +112,25 @@
 }
 
 .basicBordered :global(.ant-descriptions-view) {
-  border: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
 }
 
 .basicBordered :global(.ant-descriptions-item-label) {
   background: none;
   border-right: none;
   padding: 4px 0 !important;
+}
+
+.basicBordered :global(.ant-typography.ant-typography-secondary) {
+  color: var(--gray-7);
+}
+
+.basicBordered :global(.ant-descriptions-item-content) {
+  padding: 4px 0 !important;
+  color: var(--gray-8);
+  text-align: right;
 }
 
 @media (max-width: 1024px) {

--- a/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityVariantSummary/index.tsx
@@ -38,14 +38,16 @@ export interface ISummaryProps {
     theme?: TTheme;
 }
 
-const getDescriptionPropsBasedOnTheme = (theme: TTheme): DescriptionsProps => {
+const getDescriptionPropsBasedOnTheme = (theme: TTheme): { delimiter: string; props: DescriptionsProps } => {
     let props: DescriptionsProps = {};
+    let delimiter = '';
     switch (theme) {
         case 'basic-bordered':
             props = {
                 bordered: true,
                 className: style.basicBordered,
             };
+            delimiter = ':';
             break;
         default:
             props = {
@@ -54,8 +56,17 @@ const getDescriptionPropsBasedOnTheme = (theme: TTheme): DescriptionsProps => {
             break;
     }
 
-    return props;
+    return { delimiter, props };
 };
+
+const formatLabel = (label: ReactNode, delimiter = ''): ReactNode =>
+    delimiter ? (
+        <>
+            {label} {delimiter}
+        </>
+    ) : (
+        label
+    );
 
 export const EntityVariantSummary = ({
     data,
@@ -71,7 +82,8 @@ export const EntityVariantSummary = ({
         detailsLeftSectionLength / 2,
         detailsLeftSectionLength,
     );
-    const descriptionProps = getDescriptionPropsBasedOnTheme(theme);
+    const { delimiter, props: descriptionProps } = getDescriptionPropsBasedOnTheme(theme);
+    console.log('delimiter', delimiter); //TODO: to remove
 
     return (
         <div className={style.summaryWrapper} id={id}>
@@ -83,7 +95,7 @@ export const EntityVariantSummary = ({
                                 {data.banner.map((item: IDataItem, index: number) => (
                                     <Space direction="vertical" key={index} size={4}>
                                         <div>
-                                            <Text type="secondary">{item.label}</Text>
+                                            <Text type="secondary">{formatLabel(item.label, delimiter)}</Text>
                                         </div>
                                         <div>{item.value}</div>
                                     </Space>
@@ -108,7 +120,11 @@ export const EntityVariantSummary = ({
                                             {detailsLeftSectionCol1?.map((item: IDataItem, index: number) => (
                                                 <Descriptions.Item
                                                     key={index}
-                                                    label={<Text type="secondary">{item.label}</Text>}
+                                                    label={
+                                                        <Text type="secondary">
+                                                            {formatLabel(item.label, delimiter)}
+                                                        </Text>
+                                                    }
                                                 >
                                                     {item.value}
                                                 </Descriptions.Item>
@@ -118,7 +134,11 @@ export const EntityVariantSummary = ({
                                             {detailsLeftSectionCol2?.map((item: IDataItem, index: number) => (
                                                 <Descriptions.Item
                                                     key={index}
-                                                    label={<Text type="secondary">{item.label}</Text>}
+                                                    label={
+                                                        <Text type="secondary">
+                                                            {formatLabel(item.label, delimiter)}
+                                                        </Text>
+                                                    }
                                                 >
                                                     {item.value}
                                                 </Descriptions.Item>
@@ -140,7 +160,15 @@ export const EntityVariantSummary = ({
                                             {detail.items.map((item: IDataItem, index: number) => (
                                                 <Descriptions.Item
                                                     key={index}
-                                                    label={<span>{<Text type="secondary">{item.label}</Text>}</span>}
+                                                    label={
+                                                        <span>
+                                                            {
+                                                                <Text type="secondary">
+                                                                    {formatLabel(item.label, delimiter)}
+                                                                </Text>
+                                                            }
+                                                        </span>
+                                                    }
                                                 >
                                                     <span className={style.detailsItemValue}>{item.value}</span>
                                                 </Descriptions.Item>
@@ -159,7 +187,7 @@ export const EntityVariantSummary = ({
                                         }
                                     >
                                         {data.details.rightSection.items.map((item: IDataItem, index: number) => (
-                                            <Descriptions.Item key={index}>
+                                            <Descriptions.Item key={index} label={item.label}>
                                                 <span className={style.detailsItemValue}>{item.value}</span>
                                             </Descriptions.Item>
                                         ))}


### PR DESCRIPTION
# FIX 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SKFP-1094)

## Description
la composante descriptions n’est pas conform à la maquette. Les éspaces verticaux sont trop large. SVP voir le ticket ferlab en référence et les maquettes.

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1094)


## Screenshot
### Before
![image](https://github.com/user-attachments/assets/8991e056-058a-4a51-ac0d-fbeff36629a1)

### After
![image](https://github.com/user-attachments/assets/36bdfd40-4959-4830-8041-6343ad44d6a4)

