### PR TITLE
fix(quickfilter): SKFP-1235 fix apply button for level 2 quick filter

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.6.1 2024-08-15
+- fix: SKFP-1235 fix apply button for level 2 quick filter
+
 ### 10.6.0 2024-08-15
 - feat: CLIN-3027 add an autocomplete component
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.6.0",
+    "version": "10.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.6.0",
+            "version": "10.6.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.6.0",
+    "version": "10.6.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.css
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.css
@@ -101,6 +101,8 @@
 }
 
 .popoverFooter {
+  display: flex;
+  justify-content: flex-end;
   text-align: right;
   padding: 12px 16px;
   border-top: 1px solid var(--gray-4);
@@ -128,6 +130,7 @@
 
 .applyBtn {
   padding: 1px 8px;
+  width: auto;
 }
 
 .highlight {


### PR DESCRIPTION
# FIX 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SKFP-1235)

## Description
The apply and clear button are not well aligned. Update the alignment based on the figma design:

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1235)

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/8852174b-6c8d-488c-887d-d5db848d5a75)

### After
![image](https://github.com/user-attachments/assets/fd1593a5-1398-4071-ae9b-7725a7812b8e)


