### PR TITLE
fix(quickfilter): SJIP-952 allow quick filter button facet color theme

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.7.3 2024-08-27
+- fix: SJIP-952 allow quick filter button facet color theme
+
 ### 10.7.2 2024-08-26
 - feat: CLIN-3098 Update autocomplete component
     + manage enter press

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.7.1",
+    "version": "10.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.7.1",
+            "version": "10.7.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.7.2",
+    "version": "10.7.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.css
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.module.css
@@ -76,7 +76,7 @@
   background-color: var(--gray-3);
 }
 .facetNameWrapper .facetNameBtn {
-  color: var(--geekblue-7);
+  color: var(--sidebar-quick-filter-facet-name-btn);
   font-weight: 600;
   padding: 0;
   width: 100%;

--- a/packages/ui/themes/default/theme.template.css
+++ b/packages/ui/themes/default/theme.template.css
@@ -108,6 +108,7 @@
   --sidebar-quick-filter-input-text-color: #383f72;
   --sidebar-quick-filter-input-border-color-focus: #007694;
   --sidebar-quick-filter-higlight-color: var(--blue-2);
+  --sidebar-quick-filter-facet-name-btn: var(--geekblue-7);
   --sidebar-content-panel-padding: 16px;
   --sidebar-content-panel-width: 320px;
   --sidebar-content-panel-close-icon-color: #007694;


### PR DESCRIPTION
# FIX 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-952)

## Description

Permet de modifier la couleur des facets btn selon le theme

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-952)


## Screenshot
### Before
![image](https://github.com/user-attachments/assets/1d2bcf1e-d2d9-4b46-bf23-b28a5984c944)

### After
![image](https://github.com/user-attachments/assets/0e4fd165-ecd8-4ed0-a648-40360aa9e672)


