### PR TITLE
fix: CLIN-3220 sort flag history

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.8.3 2024-09-19
+- fix: CLIN-3047 add sort function for flag
+
 ### 10.8.2 2024-09-12
 - fix: CLIN-3047 accent replacer function to fix facet filters with accents
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.8.2",
+    "version": "10.8.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.8.2",
+            "version": "10.8.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.8.2",
+    "version": "10.8.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Flag/FlagDropdown/index.tsx
+++ b/packages/ui/src/components/Flag/FlagDropdown/index.tsx
@@ -7,6 +7,7 @@ import { getRelativeDate } from '../../../utils/dateUtils';
 import { getPractitionnerName } from '../../Assignments/utils';
 import UserAvatar from '../../UserAvatar';
 import { IFlagDictionary, TFlagHistory } from '../types';
+import { sortFlags } from '../utils';
 
 import styles from './index.module.css';
 
@@ -162,7 +163,7 @@ export const Flag = ({
                                 dot={
                                     <Space className={styles.timelineDot} size={4}>
                                         {h?.options?.length > 0
-                                            ? h.options?.map((o: string) => getOptionIcon(o))
+                                            ? sortFlags(h.options)?.map((o: string) => getOptionIcon(o))
                                             : getOptionIcon(FlagOption.NONE)}
                                     </Space>
                                 }

--- a/packages/ui/src/components/Flag/utils.test.tsx
+++ b/packages/ui/src/components/Flag/utils.test.tsx
@@ -1,0 +1,10 @@
+import { sortFlags } from './utils';
+
+describe('flags utlis', () => {
+    test('should return correct array', () => {
+        expect(sortFlags(['pin', 'flag'])).toEqual(['flag', 'pin']);
+    });
+    test('should return correct array', () => {
+        expect(sortFlags(['pin', 'star', 'flag'])).toEqual(['flag', 'pin', 'star']);
+    });
+});

--- a/packages/ui/src/components/Flag/utils.tsx
+++ b/packages/ui/src/components/Flag/utils.tsx
@@ -1,0 +1,16 @@
+import { FlagOption } from './FlagDropdown';
+
+export const sortFlags = (flags: string[]): string[] => {
+    const newArray = [];
+    if (flags.includes(FlagOption.FLAG)) {
+        newArray.push(FlagOption.FLAG);
+    }
+    if (flags.includes(FlagOption.PIN)) {
+        newArray.push(FlagOption.PIN);
+    }
+    if (flags.includes(FlagOption.STAR)) {
+        newArray.push(FlagOption.STAR);
+    }
+
+    return newArray;
+};


### PR DESCRIPTION
# FIX : L'ordre des drapeaux dans l'historique n'est pas toujours respecté

- closes #CLIN-3220

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-3220)

Acceptance Criterias

## Validation

- [ ] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/fa015034-d7ad-47cd-a42c-ecc94f1f7dd5)

### After
![image](https://github.com/user-attachments/assets/d7914f08-72a7-4bf4-a266-d8fcffae2804)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
