### PR TITLE
fix(quickfilter): SJIP-959 range should not show a button dropdown in…

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.10.8 2024-10-17
+- fix: SJIP-959 Range should not show a button dropdown in quickfilter
+
 ### 10.10.8 2024-10-16
 - fix: CLIN-3284 fix error 500 query
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.10.8",
+    "version": "10.10.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.10.8",
+            "version": "10.10.9",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.10.8",
+    "version": "10.10.9",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
+++ b/packages/ui/src/components/SidebarMenu/QuickFilter/index.tsx
@@ -250,32 +250,48 @@ const QuickFilter = ({
                                                 >
                                                     {get(dictionary, 'actions.clear', 'Clear')}
                                                 </Button>
-                                                <Dropdown.Button
-                                                    className={styles.applyBtn}
-                                                    disabled={selectedFacet && !selectedFacetOptions.length}
-                                                    menu={{
-                                                        items: [
-                                                            {
-                                                                key: TermOperators.in,
-                                                                label: get(dictionary, 'operators.anyOf', 'Any of'),
-                                                            },
-                                                            {
-                                                                key: TermOperators.all,
-                                                                label: get(dictionary, 'operators.allOf', 'All of'),
-                                                            },
-                                                            {
-                                                                key: TermOperators['not-in'],
-                                                                label: get(dictionary, 'operators.noneOf', 'None of'),
-                                                            },
-                                                        ],
-                                                        onClick: (e) => applyFacetFilters(e.key as TermOperators),
-                                                    }}
-                                                    onClick={() => applyFacetFilters(TermOperators.in)}
-                                                    size="small"
-                                                    type="primary"
-                                                >
-                                                    {get(dictionary, 'actions.apply', 'Apply')}
-                                                </Dropdown.Button>
+                                                {qfFacetOptions?.filterGroup.type != VisualType.Range ? (
+                                                    <Dropdown.Button
+                                                        className={styles.applyBtn}
+                                                        disabled={selectedFacet && !selectedFacetOptions.length}
+                                                        menu={{
+                                                            items: [
+                                                                {
+                                                                    key: TermOperators.in,
+                                                                    label: get(dictionary, 'operators.anyOf', 'Any of'),
+                                                                },
+                                                                {
+                                                                    key: TermOperators.all,
+                                                                    label: get(dictionary, 'operators.allOf', 'All of'),
+                                                                },
+                                                                {
+                                                                    key: TermOperators['not-in'],
+                                                                    label: get(
+                                                                        dictionary,
+                                                                        'operators.noneOf',
+                                                                        'None of',
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            onClick: (e) => applyFacetFilters(e.key as TermOperators),
+                                                        }}
+                                                        onClick={() => applyFacetFilters(TermOperators.in)}
+                                                        size="small"
+                                                        type="primary"
+                                                    >
+                                                        {get(dictionary, 'actions.apply', 'Apply')}
+                                                    </Dropdown.Button>
+                                                ) : (
+                                                    <Button
+                                                        className={styles.applyBtn}
+                                                        disabled={selectedFacet && !selectedFacetOptions.length}
+                                                        onClick={() => applyFacetFilters(TermOperators.in)}
+                                                        size="small"
+                                                        type="primary"
+                                                    >
+                                                        {get(dictionary, 'actions.apply', 'Apply')}
+                                                    </Button>
+                                                )}
                                             </div>
                                         </>
                                     ) : (


### PR DESCRIPTION
… quickfilter

# FIX 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-959)

## Description
Il ne devrait pas y avoir l’option “…” pour les facettes numériques.
[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-959)

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/d9905614-8276-44f7-b289-96e3d996a28e)

### After
![2024-10-17_09-51_2](https://github.com/user-attachments/assets/5da26482-45b2-4f2e-953e-2cd567c75f92)
![2024-10-17_09-51_1](https://github.com/user-attachments/assets/cd8f1821-38e5-4b23-a569-3da93a60a9d9)
![2024-10-17_09-51](https://github.com/user-attachments/assets/df186e7d-852f-4b7d-a8ba-fdf945548639)

