### PR TITLE
feat: flui-61 rangefilter default values

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.11.1",
+    "version": "10.12.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/RangeFilter.tsx
+++ b/packages/ui/src/components/filters/RangeFilter.tsx
@@ -172,15 +172,15 @@ const RangeFilter = ({
         noDataSelected = false,
         selectedMax = undefined,
         selectedMin = undefined,
-        selectedOperator = operatorsList[0].value,
+        selectedOperator = undefined,
         selectedRangeType = rangeTypes?.length ? rangeTypes[0].key : undefined,
     } = getConfig(selectedFilters);
 
     const defaultStateValue = {
-        max: selectedMax,
-        min: selectedMin,
+        max: selectedMax || range?.defaultMax,
+        min: selectedMin || range?.defaultMin,
         noDataSelected,
-        operator: selectedOperator,
+        operator: selectedOperator || range?.defaultOperator || operatorsList[0].value,
         rangeType: selectedRangeType,
     };
 

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -48,6 +48,8 @@ export interface IFilterRangeConfig {
     operators?: IRangeOperatorConfig[];
     rangeTypes?: IFilterRangeTypes[];
     defaultOperator?: RangeOperators;
+    defaultMin?: number;
+    defaultMax?: number;
     noDataInputOption?: boolean;
     intervalDecimal?: number;
 }
@@ -63,9 +65,18 @@ export interface IFilterTextInputConfig {
 
 export type TFilterGroupConfig = IFilterRangeConfig | IFilterTextInputConfig | IFilterCheckboxConfig;
 
+export interface IFilterGroupDefaultsRange {
+    min: number;
+    max: number;
+    operator: string;
+}
+
+export type TFilterGroupDefaults = IFilterGroupDefaultsRange;
+
 export interface IFilterGroup<T extends TFilterGroupConfig = any> {
     field: string;
     config?: T;
+    defaults?: TFilterGroupDefaults;
     title: ReactNode;
     type: VisualType;
     headerTooltip?: string;

--- a/packages/ui/src/data/filters/Range.ts
+++ b/packages/ui/src/data/filters/Range.ts
@@ -19,7 +19,9 @@ export const getRangeSelection = (filters: ISyntheticSqon, filterGroup: IFilterG
     let rangeSelection: IFilterRange = {
         max: undefined,
         min: undefined,
-        operator: RangeOperators['<'],
+        operator: filterGroup.config?.defaultOperator
+            ? RangeOperators[filterGroup.config?.defaultOperator as RangeOperators]
+            : RangeOperators['<'],
         rangeType: undefined,
     };
     for (const filter of filters.content) {

--- a/packages/ui/src/data/filters/utils.ts
+++ b/packages/ui/src/data/filters/utils.ts
@@ -2,7 +2,14 @@ import { isEmpty } from 'lodash';
 import get from 'lodash/get';
 import qs from 'query-string';
 
-import { IFacetDictionary, IFilter, IFilterGroup, TExtendedMapping, VisualType } from '../../components/filters/types';
+import {
+    IFacetDictionary,
+    IFilter,
+    IFilterGroup,
+    TExtendedMapping,
+    TFilterGroupDefaults,
+    VisualType,
+} from '../../components/filters/types';
 import { BooleanOperators } from '../sqon/operators';
 import { ISyntheticSqon, TSqonGroupOp, TSyntheticSqonContent } from '../sqon/types';
 import { createSQONFromFilters, isReference } from '../sqon/utils';
@@ -217,10 +224,12 @@ interface IGetFilterGroup {
     dictionary?: IFacetDictionary;
     noDataInputOption?: boolean;
     intervalDecimal?: number;
+    defaults?: TFilterGroupDefaults;
 }
 
 export const getFilterGroup = ({
     aggregation,
+    defaults,
     dictionary,
     extendedMapping,
     filterFooter,
@@ -232,6 +241,9 @@ export const getFilterGroup = ({
     if (isRangeAgg(aggregation)) {
         return {
             config: {
+                defaultMax: defaults?.max,
+                defaultMin: defaults?.min,
+                defaultOperator: defaults?.operator,
                 intervalDecimal,
                 max: aggregation.stats.max,
                 min: aggregation.stats.min,

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,7 +47,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.8.2",
+            "version": "10.11.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",
@@ -58,6 +58,7 @@
                 "@nivo/core": "^0.87.0",
                 "@nivo/pie": "^0.87.0",
                 "@nivo/scatterplot": "^0.87.0",
+                "@nivo/swarmplot": "^0.87.0",
                 "@nivo/tooltip": "^0.87.0",
                 "@react-spring/web": "^9.7.4",
                 "antd-img-crop": "^4.2.4",

--- a/storybook/stories/Components/Filters/RangeFilter.stories.tsx
+++ b/storybook/stories/Components/Filters/RangeFilter.stories.tsx
@@ -61,6 +61,46 @@ Basic.args = {
     onChange: () => undefined,
 };
 
+export const WithDefaultValue = RangeFilterStory.bind({});
+WithDefaultValue.args = {
+    title: 'RangeFilter with default Values and between operator',
+    filterGroup: {
+        type: VisualType.Range,
+        field: 'this.field',
+        config: {
+            step: 0.00001,
+            min: 0.000029,
+            max: 0.99999,
+            defaultMin: 0.2,
+            defaultMax: 0.8,
+            defaultOperator: 'between',
+        },
+        title: 'title_filter_group',
+    },
+    filters: rangeFilters,
+    onChange: () => undefined,
+};
+
+export const WithDefaultValueInOperator = RangeFilterStory.bind({});
+WithDefaultValueInOperator.args = {
+    title: 'RangeFilter with default Values and >= operator',
+    filterGroup: {
+        type: VisualType.Range,
+        field: 'this.field',
+        config: {
+            step: 0.00001,
+            min: 0.000029,
+            max: 0.99999,
+            defaultMin: 0.2,
+            defaultMax: 0.8,
+            defaultOperator: '>=',
+        },
+        title: 'title_filter_group',
+    },
+    filters: rangeFilters,
+    onChange: () => undefined,
+};
+
 export const WithFrenchTranslation = RangeFilterStory.bind({});
 WithFrenchTranslation.args = {
     title: 'RangeFilter French',


### PR DESCRIPTION
# FEAT  : default values for range filter

- closes #FLUI-61

## Description

https://ferlab-crsj.atlassian.net/browse/FLUI-61

How to use it in project:
https://github.com/include-dcc/include-portal-ui/pull/742


## Validation

- [x] Storybook add or modified
- [ ] version Update in package.json and Release.md
- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### After

https://github.com/user-attachments/assets/2abf9570-5c26-494c-af82-1812e0329dc6

