### PR TITLE
fix(cavatica): SKFP-1057 remove native tooltips for label and input

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.14.4 2024-12-11
+- fix: SJIP-1057 remove label and input native tooltips
+
 ### 10.14.3 2024-12-10
 - fix: SJIP-1127 fix submitted id case when displayed for matching results
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.14.3",
+    "version": "10.14.4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.module.css
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.module.css
@@ -1,7 +1,8 @@
-.cavaticaCreateProjectModal .billingGroupItem {
-  margin-bottom: 0;
-}
-
 .modalSubtitle {
   margin-right: 4px;
+}
+
+.cavaticaCreateProjectModal :global(.ant-select-selection-item),
+.cavaticaCreateProjectModal label {
+  pointer-events: none;
 }

--- a/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.tsx
+++ b/packages/ui/src/components/Widgets/Cavatica/CavaticaCreateProjectModal.tsx
@@ -147,6 +147,7 @@ const CavaticaCreateProjectModal = ({
     return (
         <Modal
             cancelText={dictionary.cancelText}
+            className={styles.cavaticaCreateProjectModal}
             destroyOnClose
             okButtonProps={{ disabled: !isValid }}
             okText={dictionary.okText}


### PR DESCRIPTION
# fix(cavatica): remove native tooltips for label and input

- Closes SKFP-1057

## Description
Dans la modal de création de projet Cavatica, retirer les tooltips gris du browser.
Vu dans Safari et Chrome.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SKFP-1057)


## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/76caed50-595d-4486-a322-d2a2e1f745fd)


### After
![image](https://github.com/user-attachments/assets/223cfeed-3d8d-4e01-89d2-e624c09f3c47)


