### PR TITLE
fix(facet): FLUI-61 min and max not required for default operator

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.14.6 2024-12-17
+- fix: FLUI-61 facet default operator min and max not required
+
 ### 10.14.5 2024-12-13
 - feat: PRESC-341 option show ldm assigment
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.14.2",
+    "version": "10.14.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.14.2",
+            "version": "10.14.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.14.5",
+    "version": "10.14.6",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -67,8 +67,8 @@ export interface IFilterTextInputConfig {
 export type TFilterGroupConfig = IFilterRangeConfig | IFilterTextInputConfig | IFilterCheckboxConfig;
 
 export interface IFilterGroupDefaultsRange {
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
     operator: string;
 }
 

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,7 +47,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.14.2",
+            "version": "10.14.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.7.0",


### PR DESCRIPTION
# fix(facet): min and max not required for default operator

[FLUI-61](https://ferlab-crsj.atlassian.net/browse/FLUI-61)

## Description
Make min and max properties not required in default range operator.

## Acceptance Criterias
Be able to define default operator without define min and max

[FLUI-61]: https://ferlab-crsj.atlassian.net/browse/FLUI-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ