### PR TITLE
feat(venn): SJIP-1116 prevent clicking on disabled section

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,4 +1,7 @@
-### 10.16.6 2025-02-26
+### 10.16.7 2025-02-26
+- fix: SJIP-1116 prevent active a disabled section
+
+### 10.16.6 2025-02-25
 - fix: SJIP-1116 format entity count
 
 ### 10.16.5 2025-02-25

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.16.6",
+    "version": "10.16.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.16.6",
+            "version": "10.16.7",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.16.6",
+    "version": "10.16.7",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/index.tsx
@@ -622,6 +622,9 @@ const VennChart = ({
             .on('click', (d) => {
                 analytics.trackVennClickOnSections();
                 const element = d3.select(d.srcElement);
+                const disabled = element.classed(styles.disabled) ? true : false;
+                if (disabled) return;
+
                 const active = element.classed(styles.active) ? false : true;
                 element.classed(styles.active, active);
                 const { id } = d.srcElement;


### PR DESCRIPTION
# feat(venn): prevent clicking on disabled section

- Closes SJIP-1116

## Description
Issue: Although the section is disabled with 0 results in the diagram, we can still click it and it will create a checkmark in the checkbox for that section in the table. We shouldn’t be able to check it from the venn diagram

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1116)

## Screenshot or Video

https://github.com/user-attachments/assets/03e62f71-6dfc-41de-85bd-4ddb572adf64

