### PR TITLE
feat(entity): SKFP-1469 manage long title

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.16.9 2025-03-05
+- feat: SKFP-1469 Manage long title in entity title
+
 ### 10.16.8 2025-03-05
 - fix: CLIN-3908 Add scrollbar-gutter popover columnsort protable
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.16.8",
+    "version": "10.16.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.16.8",
+            "version": "10.16.9",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.16.8",
+    "version": "10.16.9",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityTitle/index.module.css
+++ b/packages/ui/src/pages/EntityPage/EntityTitle/index.module.css
@@ -1,19 +1,25 @@
 .titleHeader {
-  margin-bottom: 16px;
-  display: flex;
-  align-items: center;
-  color: var(--heading-color);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    color: var(--heading-color);
 }
 .titleHeader .title {
-  margin-left: 12px;
-  margin-bottom: 0;
+    margin-left: 12px;
+    margin-bottom: 0;
+}
+.titleHeader .titleTooltip {
+    overflow: hidden;
+    max-width: 40ch;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 .titleHeader .tag {
-  margin-left: 12px;
+    margin-left: 12px;
 }
 .titleHeader .extra {
-  margin-left: auto;
+    margin-left: auto;
 }
 .titleHeader .icon {
-  font-size: var(--entity-icon-size);
+    font-size: var(--entity-icon-size);
 }

--- a/packages/ui/src/pages/EntityPage/EntityTitle/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityTitle/index.tsx
@@ -1,24 +1,32 @@
 import React from 'react';
-import { Skeleton } from 'antd';
+import { Skeleton, Tooltip } from 'antd';
 import Title from 'antd/lib/typography/Title';
+import cx from 'classnames';
 
 import styles from './index.module.css';
 
 export interface IEntityTitle {
     text?: string;
+    textWithTooltip?: boolean;
     icon: React.ReactNode;
     tag?: React.ReactNode;
     extra?: React.ReactNode;
     loading?: boolean;
 }
 
-const EntityTitle: React.FC<IEntityTitle> = ({ extra, icon, loading, tag, text }) =>
+const EntityTitle: React.FC<IEntityTitle> = ({ extra, icon, loading, tag, text, textWithTooltip }) =>
     loading ? (
         <Skeleton loading={loading} paragraph={{ rows: 0 }} />
     ) : (
         <div className={styles.titleHeader}>
             {icon && <span className={styles.icon}>{icon}</span>}
-            {text && (
+            {text && text.length > 40 && textWithTooltip ? (
+                <Tooltip title={text}>
+                    <Title className={cx(styles.title, styles.titleTooltip)} level={4}>
+                        {text}
+                    </Title>
+                </Tooltip>
+            ) : (
                 <Title className={styles.title} level={4}>
                     {text}
                 </Title>


### PR DESCRIPTION
# feat(entity): update version

[SKFP-1469](https://ferlab-crsj.atlassian.net/browse/SKFP-1469)

## Description
Manage title entity display

## Acceptance Criterias
- Add tooltip and ellipsis on long title in entity

## Screenshot or Video
### Before
![image-20250305-163000](https://github.com/user-attachments/assets/6dd50f38-1efe-410c-bc58-28d8e8283e06)

### After
<img width="693" alt="Capture d’écran, le 2025-03-05 à 15 36 14" src="https://github.com/user-attachments/assets/adcdce64-95df-40c5-9a96-04f45cd4a294" />
