### PR TITLE
fix(venn): SJIP-1248 fix an issue where combined operators will make venn diagram crash

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.17.2 2025-03-11
+- fix: SJIP-1248 fix an issue where combined operators will make venn diagram crash
+
 ### 10.17.1 2025-03-06
 - feat: SJIP-1243 Add tab switching, icons and various bugsfix
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.17.0",
+    "version": "10.17.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.17.0",
+            "version": "10.17.2",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.17.1",
+    "version": "10.17.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/index.tsx
+++ b/packages/ui/src/components/QueryBuilder/index.tsx
@@ -4,7 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import { v4 } from 'uuid';
 
 import { BooleanOperators } from '../../data/sqon/operators';
-import { IRemoteComponent, ISqonGroupFilter, ISyntheticSqon, TSyntheticSqonContent } from '../../data/sqon/types';
+import { IRemoteComponent, ISyntheticSqon, TSyntheticSqonContent } from '../../data/sqon/types';
 import {
     changeCombineOperator,
     getDefaultSyntheticSqon,
@@ -14,6 +14,7 @@ import {
     removeContentFromSqon,
     removeQueryFromSqon,
     removeSqonAtIndex,
+    resolveSyntheticSqon,
 } from '../../data/sqon/utils';
 import ConditionalWrapper from '../utils/ConditionalWrapper';
 
@@ -427,9 +428,15 @@ const QueryBuilder = ({
                                 addNewQuery={addNewQuery}
                                 enableCompare={handleCompare !== undefined}
                                 handleCompare={() => {
-                                    const queriesToCompare = queryStateQueriesWithoutFilter.filter((_, index) =>
-                                        selectedQueryIndices.includes(index),
-                                    );
+                                    const queriesToCompare = queryStateQueriesWithoutFilter
+                                        .filter((_, index) => selectedQueryIndices.includes(index))
+                                        .map((query) => ({
+                                            ...query,
+                                            content: resolveSyntheticSqon(queryStateQueriesWithoutFilter, query)
+                                                .content,
+                                            op: query.op || BooleanOperators.and,
+                                        }));
+
                                     handleCompare && handleCompare(queriesToCompare);
                                     setSelectedQueryIndices([]);
                                 }}


### PR DESCRIPTION
# fix(venn): fix an issue where combined operators will make venn diagram crash

- Closes SJIP-1248

## Description
When attempting to create a venn with a query with combined queries pills in it, it causes an error 500. See the saved filter below and attempt to create a venn with a combined query.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1248)

## Screenshot or Video

https://github.com/user-attachments/assets/ce1f954c-30aa-442f-bd70-7de2f68d9015

