### PR TITLE
fix(venn): SJIP-1257 force static width and height for venn

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.17.3 2025-03-11
+- fix: SJIP-1257 force static width, height for venn to prevent getBoundingRect issue
+
 ### 10.17.2 2025-03-11
 - fix: SJIP-1248 fix an issue where combined operators will make venn diagram crash
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.17.2",
+    "version": "10.17.3",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/VennModal.tsx
+++ b/packages/ui/src/components/Charts/Venn/VennModal.tsx
@@ -18,12 +18,16 @@ type VennModalDictionary = TVennChartDictionary & {
     ok: string;
 };
 
-type VennModalProps = TVennChart & {
+type VennModalProps = Omit<TVennChart, 'size'> & {
     queryPillDictionary?: IDictionary;
     dictionary?: VennModalDictionary;
     open?: boolean;
     error?: boolean;
     width?: number;
+    vennSize: {
+        width: number;
+        height: number;
+    };
 };
 
 const VennModal = ({
@@ -41,6 +45,7 @@ const VennModal = ({
     queryPillDictionary = {},
     savedSets,
     summary,
+    vennSize,
     width = 1338,
 }: VennModalProps): JSX.Element => (
     <QueryDictionaryContext.Provider value={{ dictionary: queryPillDictionary }}>
@@ -68,6 +73,7 @@ const VennModal = ({
                     operations={operations}
                     options={options}
                     savedSets={savedSets}
+                    size={vennSize}
                     summary={summary}
                 />
             )}

--- a/packages/ui/src/components/Charts/Venn/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/index.tsx
@@ -150,6 +150,10 @@ export type TVennChart = {
     factor?: number;
     summary?: ISummaryData[];
     operations?: ISetOperation[];
+    size: {
+        width: number;
+        height: number;
+    };
     analytics: {
         trackVennViewInExploration: () => void;
         trackVennClickOnSections: () => void;
@@ -239,6 +243,7 @@ const VennChart = ({
     outlineWidth = 1.5,
     radius = 130,
     savedSets,
+    size,
     summary = [],
 }: TVennChart): JSX.Element => {
     const [form] = Form.useForm();
@@ -261,15 +266,14 @@ const VennChart = ({
     const chartId = `venn-chart-${v4()}`;
 
     useEffect(() => {
-        if (!ref?.current) return;
-        if (loading) return;
+        if (loading || !ref?.current) return;
 
+        const { height, width } = size;
         const circle1 = `circle1-${v4()}`;
         const circle1out = `circle1_out-${v4()}`;
         const circle2 = `circle2-${v4()}`;
         const circle2out = `circle2_out-${v4()}`;
 
-        const { height, width } = ref.current.getBoundingClientRect();
         const cy = (1.0 / summary.length) * height + PADDING_OFFSET;
         const cx = 0.48 * width;
         const svg = d3.select(`#${chartId}`);

--- a/storybook/stories/Components/Chart/venn.stories.tsx
+++ b/storybook/stories/Components/Chart/venn.stories.tsx
@@ -218,6 +218,10 @@ export const VennLoading = () => (
                         throw new Error('Function not implemented.');
                     },
                 }}
+                size={{
+                    width: 540,
+                    height: 498,
+                }}
             />
         </div>
     </>
@@ -275,6 +279,10 @@ export const VennChartWithTwoSets = () => (
                     trackVennViewEntityCounts: function (type: string, entityCount: number): void {
                         throw new Error('Function not implemented.');
                     },
+                }}
+                size={{
+                    width: 540,
+                    height: 498,
                 }}
             />
         </div>
@@ -334,6 +342,10 @@ export const VennChartWithThreeSets = () => (
                         throw new Error('Function not implemented.');
                     },
                 }}
+                size={{
+                    width: 540,
+                    height: 498,
+                }}
             />
         </div>
     </>
@@ -392,6 +404,10 @@ export const VennChartWithThreeSetsWithInvalidValues = () => (
                         throw new Error('Function not implemented.');
                     },
                 }}
+                size={{
+                    width: 540,
+                    height: 498,
+                }}
             />
         </div>
     </>
@@ -449,6 +465,10 @@ export const VennChartWithEntitySwitchedByDefault = () => (
                     trackVennViewEntityCounts: function (type: string, entityCount: number): void {
                         throw new Error('Function not implemented.');
                     },
+                }}
+                size={{
+                    width: 540,
+                    height: 498,
                 }}
             />
         </div>


### PR DESCRIPTION
# fix(venn): force static width and height for venn

- Closes SJIP-1257

## Description
When creating a venn with 2 queries, it caused a shifting of the display. Below are the two queries used. It doesn’t happen all the time but I opened it 5 times and the shifting occurred 2/5 times. 
![image](https://github.com/user-attachments/assets/70e3e3aa-745c-4761-979a-db2d28d02476)


## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1257)


## Screenshot or Video
![image](https://github.com/user-attachments/assets/b61a605d-46a8-45e6-a51d-14c341b3023f)
![image](https://github.com/user-attachments/assets/130af0be-7acc-461e-8169-e157d404141a)
