### PR TITLE
feat(entity): SJIP-1235 add custom content entity

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.18.0 2025-03-11
+- feat: SJIP-1235 Add custom content entity component
+
 ### 10.17.3 2025-03-11
 - fix: SJIP-1257 force static width, height for venn to prevent getBoundingRect issue
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.17.2",
+    "version": "10.18.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.17.2",
+            "version": "10.18.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.17.3",
+    "version": "10.18.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityCustomContent/index.module.css
+++ b/packages/ui/src/pages/EntityPage/EntityCustomContent/index.module.css
@@ -1,0 +1,16 @@
+.container {
+    max-width: 1600px;
+    margin-bottom: 40px;
+}
+.container .title {
+    margin-bottom: 16px;
+}
+.container .collapse .panel .card {
+    border: none;
+}
+.container .collapse .panel .card *[class$='-card-body'] {
+    padding: 0;
+}
+.container .collapse .panel .card .content {
+    width: 100%;
+}

--- a/packages/ui/src/pages/EntityPage/EntityCustomContent/index.test.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityCustomContent/index.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import EntityCustomContent from '.';
+
+const customContent = <span>Custom content</span>;
+
+describe('EntityPage/EntityCustomContent', () => {
+    test('make sure content is not rendered while loading', () => {
+        const props = {
+            customContent,
+            header: 'Header',
+            id: 'ID',
+            loading: true,
+            title: 'Title',
+        };
+
+        render(<EntityCustomContent {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByText('Custom content')).toBeNull();
+    });
+    test('make sure Title is rendered when the props is defined', () => {
+        const props = {
+            customContent,
+            header: 'Header',
+            id: 'ID',
+            loading: false,
+            title: 'Title',
+        };
+
+        render(<EntityCustomContent {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+    });
+    test('make sure Title is NOT rendered when the props is undefined', () => {
+        const props = {
+            customContent,
+            header: 'Header',
+            id: 'ID',
+            loading: false,
+        };
+
+        render(<EntityCustomContent {...props} />);
+        expect(screen.queryByText('Title')).toBeNull();
+    });
+
+    test('make sure to display a Custom Content if it is not empty', () => {
+        const props = {
+            customContent,
+            emptyMessage: 'Is empty',
+            header: 'Header',
+            id: 'ID',
+            loading: false,
+        };
+
+        render(<EntityCustomContent {...props} />);
+        expect(screen.queryByText(props.emptyMessage)).toBeNull();
+        expect(screen.getByText('Custom content')).toBeTruthy();
+    });
+
+    test('make sure to display "No data available" if custom content is empty', () => {
+        const props = {
+            customContent: undefined,
+            emptyMessage: 'Is empty',
+            header: 'Header',
+            id: 'ID',
+            loading: false,
+        };
+
+        render(<EntityCustomContent {...props} />);
+        expect(screen.getByText(props.emptyMessage)).toBeTruthy();
+        expect(screen.queryByText('Custom content')).toBeNull();
+    });
+});

--- a/packages/ui/src/pages/EntityPage/EntityCustomContent/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityCustomContent/index.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode } from 'react';
+import { Card, Space, Typography } from 'antd';
+
+import Collapse, { CollapsePanel } from '../../../components/Collapse';
+import Empty from '../../../components/Empty';
+
+import styles from './index.module.css';
+const { Title } = Typography;
+
+export interface IEntityCustomContent {
+    customContent: ReactNode;
+    header: React.ReactNode;
+    id: string;
+    loading: boolean;
+    title?: string;
+    titleExtra?: ReactNode[];
+    emptyMessage?: string;
+    total?: number;
+}
+
+const EntityCustomContent = ({
+    customContent,
+    emptyMessage = 'No data available',
+    header,
+    id,
+    loading,
+    title,
+    titleExtra,
+    total = 0,
+}: IEntityCustomContent): React.ReactElement => (
+    <div className={styles.container} id={id}>
+        {title && (
+            <Title className={styles.title} level={4}>
+                {title}
+            </Title>
+        )}
+        <Collapse arrowIcon="caretFilled" className={styles.collapse} defaultActiveKey={['1']}>
+            <CollapsePanel
+                className={styles.panel}
+                extra={titleExtra}
+                header={
+                    <Space size={2}>
+                        {header} {total > 0 && <span>({total})</span>}
+                    </Space>
+                }
+                key="1"
+            >
+                <Card className={styles.card} loading={loading}>
+                    {!loading && customContent ? (
+                        <Space className={styles.content} direction="vertical" size={0}>
+                            {customContent}
+                        </Space>
+                    ) : (
+                        <Space className={styles.content} direction="vertical" size={12}>
+                            <Empty align="left" description={emptyMessage} noPadding showImage={false} size="mini" />
+                        </Space>
+                    )}
+                </Card>
+            </CollapsePanel>
+        </Collapse>
+    </div>
+);
+
+export default EntityCustomContent;

--- a/packages/ui/src/pages/EntityPage/index.tsx
+++ b/packages/ui/src/pages/EntityPage/index.tsx
@@ -4,6 +4,7 @@ import HpoConditionCell from './EntityConditionsCell/HpoConditionCell';
 import OmimConditionCell from './EntityConditionsCell/OmimConditionCell';
 import OrphanetConditionCell from './EntityConditionsCell/OrphanetConditionCell';
 import EntityGeneConsequenceSubtitle from './EntityGeneConsequence/EntityGeneConsequenceSubtitle';
+import EntityCustomContent, { IEntityCustomContent } from './EntityCustomContent';
 import EntityDataset from './EntityDataset';
 import EntityDescriptions, { IEntityDescriptions, IEntityDescriptionsItem } from './EntityDescriptions';
 import EntityExpandableTableMultiple from './EntityExpandableTableMultiple';
@@ -20,6 +21,7 @@ import EntityTitleLogo, { IEntityTitleLogo } from './EntityTitleLogo';
 export {
     CosmicConditionCell,
     DddConditionCell,
+    EntityCustomContent,
     EntityDataset,
     EntityDescriptions,
     EntityExpandableTableMultiple,
@@ -34,6 +36,7 @@ export {
     EntityTitle,
     EntityTitleLogo,
     HpoConditionCell,
+    IEntityCustomContent,
     IEntityDescriptions,
     IEntityDescriptionsItem,
     IEntityTable,

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,10 +47,11 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.16.0",
+            "version": "10.18.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",
+                "@ant-design/icons-svg": "^4.4.2",
                 "@dnd-kit/core": "^4.0.3",
                 "@dnd-kit/sortable": "^5.1.0",
                 "@dnd-kit/utilities": "^3.2.0",
@@ -62,7 +63,7 @@
                 "antd-img-crop": "^4.2.4",
                 "classnames": "^2.2.6",
                 "command-line-args": "^5.1.1",
-                "cross-spawn": "^7.0.3",
+                "cross-spawn": "^7.0.6",
                 "d3": "^7.9.0",
                 "d3-svg-to-png": "^0.3.1",
                 "history": "^4.9.0",

--- a/storybook/stories/Pages/EntityPage/EntityCustomContent.stories.tsx
+++ b/storybook/stories/Pages/EntityPage/EntityCustomContent.stories.tsx
@@ -1,0 +1,36 @@
+import EntityCustomContent, { IEntityCustomContent } from '@ferlab/ui/core/pages/EntityPage/EntityCustomContent';
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { AiOutlineUsergroupAdd } from 'react-icons/ai';
+
+export default {
+    title: '@ferlab/Pages/EntityPage/EntityCustomContent',
+    component: EntityCustomContent,
+    decorators: [
+        (Story) => (
+            <>
+                <h2>{Story}</h2>
+                <Story />
+            </>
+        ),
+    ],
+} as Meta;
+
+const EntityCustomContentStory = ({ storyTitle, ...props }: { storyTitle: string; props: IEntityCustomContent }) => (
+    <>
+        <h3>{storyTitle}</h3>
+        <EntityCustomContent {...props} />
+    </>
+);
+
+export const BasicEntityCustomContent = EntityCustomContentStory.bind({});
+BasicEntityCustomContent.args = {
+    customContent: <>Custom content</>,
+    header: 'Header',
+    id: 'Section',
+    loading: false,
+    size: 'small',
+    title: 'Title',
+    titleExtra: [<span>View in data exploration</span>],
+    emptyMessage: 'No data available',
+};


### PR DESCRIPTION
# feat(entity): add custom content entity

[SJIP-1235](https://ferlab-crsj.atlassian.net/browse/SJIP-1235)

## Description
- Add custom content entity panel

## Acceptance Criterias
- Be able to add collapsable entity panel with custom content

## Screenshot or Video
### Before
NA

### After
<img width="1537" alt="Capture d’écran, le 2025-03-11 à 17 40 26" src="https://github.com/user-attachments/assets/0bd950d2-1b08-4605-9f8f-ddb6f2ee412a" />
