### PR TITLE
feat(biospecimen): SJIP-1235 add size props to request biospecimen

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.18.1 2025-03-17
+- feat: SJIP-1235 Add size props to request biospecimen button
+
 ### 10.18.0 2025-03-11
 - feat: SJIP-1235 Add custom content entity component
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.18.0",
+    "version": "10.18.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.18.0",
+            "version": "10.18.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.18.0",
+    "version": "10.18.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/BiospecimenRequest/RequestBiospecimenButton.tsx
+++ b/packages/ui/src/components/BiospecimenRequest/RequestBiospecimenButton.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Button, Tooltip } from 'antd';
+import { SizeType } from 'antd/lib/config-provider/SizeContext';
 import { ColumnType } from 'antd/lib/table';
 
 import { ISqonGroupFilter } from '../../data/sqon/types';
@@ -23,6 +24,7 @@ interface RequestBiospecimenButtonProps {
     getSavedSets: () => IGetSavedSets;
     maxTitleLength?: number;
     nbBiospecimenSelected: number;
+    size?: SizeType;
     sqon?: ISqonGroupFilter;
     type?: 'default' | 'primary';
 }
@@ -38,6 +40,7 @@ const RequestBiospecimenButton = ({
     getSavedSets,
     maxTitleLength = BIOSPECIMENT_REQUEST_MAX_TITLE_LENGTH,
     nbBiospecimenSelected,
+    size = undefined,
     sqon,
     type = 'default',
 }: RequestBiospecimenButtonProps): ReactElement => {
@@ -57,7 +60,7 @@ const RequestBiospecimenButton = ({
     return (
         <>
             <Tooltip title={disabled ? dictionary.itemSelectionTooltip : undefined}>
-                <Button disabled={disabled} onClick={handleClick} type={type}>
+                <Button disabled={disabled} onClick={handleClick} size={size} type={type}>
                     {dictionary.buttonLabel}
                 </Button>
             </Tooltip>


### PR DESCRIPTION
# feat(biospecimen): add size props to request biospecimen button

[SJIP-1235](https://ferlab-crsj.atlassian.net/browse/SJIP-1235)

## Description
Be able to change button size.

## Acceptance Criterias
- Add size props du request biospecimen button

## Screenshot or Video
### Before
<img width="656" alt="Capture d’écran, le 2025-03-17 à 15 10 40" src="https://github.com/user-attachments/assets/1b139fe2-9533-4c12-b38c-46261b43eb73" />

### After
<img width="656" alt="Capture d’écran, le 2025-03-17 à 15 10 04" src="https://github.com/user-attachments/assets/dd89eb1c-5186-488c-b2e5-dc2034946fbe" />
