### PR TITLE
feat(pageheader): SJIP-1254 add page header component

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.19.0 2025-03-26
+- feat: SJIP-1254 Add PageHeader layout component
+
 ### 10.18.4 2025-03-20
 - fix: SKFP-1485 Add validation on quick filter input
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.18.4",
+    "version": "10.19.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.18.4",
+            "version": "10.19.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.18.4",
+    "version": "10.19.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/PageHeader/index.module.css
+++ b/packages/ui/src/layout/PageHeader/index.module.css
@@ -1,0 +1,31 @@
+.pageHeaderWrapper {
+    display: flex;
+    padding: 16px 24px;
+    align-items: flex-start;
+    flex-direction: column;
+}
+
+.backTitleWrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.iconWrapper {
+    font-size: 22px;
+}
+
+.title {
+    margin: 0 !important;
+}
+
+.subtitle {
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 22px;
+    color: var(--gray-7);
+}
+.withBack {
+    padding-left: 36px;
+}

--- a/packages/ui/src/layout/PageHeader/index.test.tsx
+++ b/packages/ui/src/layout/PageHeader/index.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import PageHeader from '.';
+
+describe('layout/PageHeader', () => {
+    test('make sure render title only if no other props filled', () => {
+        const props = {
+            title: 'Title',
+        };
+
+        render(<PageHeader {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByText('Subtitle')).toBeNull();
+        expect(screen.queryByText('Icon')).toBeNull();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+    test('make sure render back button if it is filled', () => {
+        const props = {
+            onBackButton: jest.fn(),
+            title: 'Title',
+        };
+
+        render(<PageHeader {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByRole('button')).toBeTruthy();
+        expect(screen.queryByText('Subtitle')).toBeNull();
+        expect(screen.queryByText('Icon')).toBeNull();
+    });
+    test('make sure render subtitle if it is filled', () => {
+        const props = {
+            subtitle: 'Subtitle',
+            title: 'Title',
+        };
+
+        render(<PageHeader {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByText('Subtitle')).toBeTruthy();
+        expect(screen.queryByText('Icon')).toBeNull();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+    test('make sure render icon if it is filled', () => {
+        const props = {
+            icon: <>Icon</>,
+            title: 'Title',
+        };
+
+        render(<PageHeader {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByText('Icon')).toBeTruthy();
+        expect(screen.queryByText('Subtitle')).toBeNull();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+    test('make sure render all if all props are filled', () => {
+        const props = {
+            icon: <>Icon</>,
+            onBackButton: jest.fn(),
+            subtitle: 'Subtitle',
+            title: 'Title',
+        };
+
+        render(<PageHeader {...props} />);
+        expect(screen.getByText('Title')).toBeTruthy();
+        expect(screen.queryByText('Icon')).toBeTruthy();
+        expect(screen.queryByText('Subtitle')).toBeTruthy();
+        expect(screen.queryByRole('button')).toBeTruthy();
+    });
+});

--- a/packages/ui/src/layout/PageHeader/index.tsx
+++ b/packages/ui/src/layout/PageHeader/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { Button, Space, Typography } from 'antd';
+import cx from 'classnames';
+
+import styles from './index.module.css';
+
+export interface IPageHeader {
+    icon?: React.ReactNode;
+    iconClassname?: string;
+    onBackButton?: () => void;
+    title: React.ReactNode;
+    titleClassname?: string;
+    subtitle?: React.ReactNode;
+    subtitleClassname?: string;
+}
+
+const PageHeader = ({
+    icon,
+    iconClassname = '',
+    onBackButton,
+    subtitle,
+    subtitleClassname = '',
+    title,
+    titleClassname = '',
+}: IPageHeader): React.ReactElement => (
+    <div className={styles.pageHeaderWrapper}>
+        <div className={styles.backTitleWrapper}>
+            {onBackButton && <Button icon={<ArrowLeftOutlined />} onClick={onBackButton} size="small" type="text" />}
+            <Space size={8}>
+                {icon && <div className={cx(styles.iconWrapper, iconClassname && iconClassname)}>{icon}</div>}
+                <Typography.Title className={cx(styles.title, titleClassname && titleClassname)} level={4}>
+                    {title}
+                </Typography.Title>
+            </Space>
+        </div>
+        {subtitle && (
+            <div
+                className={cx(styles.subtitle, onBackButton && styles.withBack, subtitleClassname && subtitleClassname)}
+            >
+                {subtitle}
+            </div>
+        )}
+    </div>
+);
+
+export default PageHeader;

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,7 +47,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.18.0",
+            "version": "10.19.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/storybook/stories/Layout/PageHeader.stories.tsx
+++ b/storybook/stories/Layout/PageHeader.stories.tsx
@@ -1,0 +1,59 @@
+import PageHeader, { IPageHeader } from '@ferlab/ui/core/layout/PageHeader';
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { FileSearchOutlined, InfoCircleOutlined } from '@ant-design/icons';
+
+export default {
+    title: '@ferlab/Layout/PageHeader',
+    component: PageHeader,
+    decorators: [
+        (Story) => (
+            <>
+                <h2>{Story}</h2>
+                <Story />
+            </>
+        ),
+    ],
+} as Meta;
+
+const PageHeaderStory = ({ storyTitle, ...props }: { storyTitle: string; props: IPageHeader }) => (
+    <>
+        <h3>{storyTitle}</h3>
+        <PageHeader {...props} />
+    </>
+);
+
+export const BasicPageHeader = PageHeaderStory.bind({});
+BasicPageHeader.args = {
+    title: 'Title',
+};
+
+export const BackButtonPageHeader = PageHeaderStory.bind({});
+BackButtonPageHeader.args = {
+    title: 'Title',
+    onBackButton: () => alert('Back button clicked'),
+};
+
+export const IconPageHeader = PageHeaderStory.bind({});
+IconPageHeader.args = {
+    title: 'Title',
+    icon: <FileSearchOutlined />,
+};
+
+export const SubtitlePageHeader = PageHeaderStory.bind({});
+SubtitlePageHeader.args = {
+    title: 'Title',
+    subtitle: 'Subtitle',
+};
+
+export const AllPropsPageHeader = PageHeaderStory.bind({});
+AllPropsPageHeader.args = {
+    title: (
+        <>
+            Title <InfoCircleOutlined style={{ marginLeft: '8px', fontSize: '16px' }} />
+        </>
+    ),
+    icon: <FileSearchOutlined />,
+    onBackButton: () => alert('Back button clicked'),
+    subtitle: 'Subtitle',
+};


### PR DESCRIPTION
# feat(pageheader): add page header component

[SJIP-1254](https://ferlab-crsj.atlassian.net/browse/SJIP-1254)

## Description
Add page header

## Acceptance Criterias
Add page header with icon, back and subtitle options

## Screenshot or Video
### Before
NA

### After
<img width="769" alt="Capture d’écran, le 2025-03-26 à 12 11 31" src="https://github.com/user-attachments/assets/abb07c1c-5a6f-4e53-a235-14d71548ca6d" />
<img width="769" alt="Capture d’écran, le 2025-03-26 à 09 41 54" src="https://github.com/user-attachments/assets/d7769908-eadc-4d43-a292-411ae122b4a7" />
