### PR TITLE
feat(venn): SJIP-1299 add download button for venn chart

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.22.0 2025-04-08
+- feat: SJIP-1299 add download button for venn chart
+
 ### 10.21.2 2025-04-08
 - fix: SJIP-1297 manage dropdown in venn with filters
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.21.2",
+    "version": "10.22.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.21.2",
+            "version": "10.22.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.21.2",
+    "version": "10.22.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/VennChartWithSelect.tsx
+++ b/packages/ui/src/components/Charts/Venn/VennChartWithSelect.tsx
@@ -20,6 +20,9 @@ enum Index {
 export const DEFAULT_VENN_CHART_DICTIONARY: TVennChartDictionary = {
     biospecimens: 'Biospecimens',
     count: 'Count :',
+    download: {
+        png: 'Download PNG',
+    },
     files: 'Files',
     filters: {
         compareButton: 'Compare',

--- a/packages/ui/src/components/Charts/Venn/index.module.css
+++ b/packages/ui/src/components/Charts/Venn/index.module.css
@@ -143,3 +143,8 @@
 .saveForm :global(.ant-form-item):last-child {
   margin-bottom: 0;
 }
+
+.venn .svg {
+  width: 100%;
+  height: calc(100% - 43px);
+}

--- a/packages/ui/src/components/Charts/Venn/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/index.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useEffect, useRef } from 'react';
+import { DownloadOutlined } from '@ant-design/icons';
 import { Button, Divider, Table, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import classnames from 'classnames';
 import * as d3 from 'd3';
+import d3ToPng from 'd3-svg-to-png';
 import { v4 } from 'uuid';
 
+import { DownloadType, fileNameFormatter } from '../../../layout/ResizableGridLayout/ResizableGridCard/utils';
 import { numberFormat } from '../../../utils/numberUtils';
 import ExternalLinkIcon from '../../ExternalLink/ExternalLinkIcon';
 
@@ -16,6 +19,14 @@ import styles from './index.module.css';
 const MAX_COUNT = 10000;
 const PADDING_OFFSET = 24;
 const LABELS = ['Q₁', 'Q₂', 'Q₃'];
+
+const EXPORT_SETTINGS = {
+    background: 'white',
+    quality: 1,
+    scale: 2,
+};
+const DEFAULT_FILENAME_TEMPLATE = '%name-%type-%date%extension';
+const DEFAULT_FILENAME_DATE_FORMAT = 'yyyy-MM-dd';
 
 type VennChartProps = {
     analytics: {
@@ -534,7 +545,25 @@ const VennChart = ({
             <div className={styles.chart}>
                 <div className={styles.chartWrapper}>
                     <div className={styles.chartContent} ref={ref}>
-                        <svg height="100%" id={chartId} width="100%" />
+                        <svg className={styles.svg} id={chartId} />
+                        <Button
+                            icon={<DownloadOutlined />}
+                            onClick={() => {
+                                const fileName = fileNameFormatter(
+                                    dictionary.download.fileNameTemplate ?? DEFAULT_FILENAME_TEMPLATE,
+                                    DownloadType.chart,
+                                    dictionary.download.fileNameDateFormat ?? DEFAULT_FILENAME_DATE_FORMAT,
+                                    'venn',
+                                    '',
+                                );
+                                d3ToPng(`#${chartId}`, fileName, {
+                                    ...EXPORT_SETTINGS,
+                                    format: 'png',
+                                });
+                            }}
+                        >
+                            {dictionary.download.png}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/packages/ui/src/components/Charts/Venn/utils.tsx
+++ b/packages/ui/src/components/Charts/Venn/utils.tsx
@@ -17,6 +17,11 @@ export type TVennChartDictionary = {
     count: string;
     participants: string;
     biospecimens: string;
+    download: {
+        png: string;
+        fileNameTemplate?: string;
+        fileNameDateFormat?: string;
+    };
     files: string;
     filters?: {
         compareButton: string;


### PR DESCRIPTION
# feat(venn): add download button for venn chart

- Closes SJIP-1299

## Description
Add Download PNG feature to Venn Diagram in Data exploration and in Set operations (analytics).

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1299)


## Screenshot or Video
![image](https://github.com/user-attachments/assets/6480cce6-03b9-4693-b1dc-c3a137341b72)
![image](https://github.com/user-attachments/assets/e3cf104c-cd1e-44dd-8f48-4d644a217c88)
![image](https://github.com/user-attachments/assets/5ba7bc27-ae25-425c-b12b-e42e66860168)
