### PR TITLE
fix(venn): SKFP-1504 manage somatic in venn

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.23.1 2025-04-17
+- fix: SKFP-1504 manage somatic in venn diagram
+
 ### 10.23.0 2025-04-17
 - feat: SJIP-1318 add preview version of clinical trial timeline chart
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.23.0",
+    "version": "10.23.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.23.0",
+            "version": "10.23.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.23.0",
+    "version": "10.23.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/index.tsx
@@ -9,6 +9,7 @@ import { v4 } from 'uuid';
 
 import { DownloadType, fileNameFormatter } from '../../../layout/ResizableGridLayout/ResizableGridCard/utils';
 import { numberFormat } from '../../../utils/numberUtils';
+import { SetType } from '../../BiospecimenRequest/requestBiospecimen.utils';
 import ExternalLinkIcon from '../../ExternalLink/ExternalLinkIcon';
 
 import { ISetOperation, ISummaryData, TOption, TVennChartDictionary } from './utils';
@@ -109,7 +110,7 @@ const getOperationColumns = ({
                 title={
                     record.entityCount > MAX_COUNT
                         ? dictionary.set.max
-                        : entity === 'variants'
+                        : entity === SetType.VARIANT || entity === SetType.SOMATIC
                         ? dictionary.set.tooltipVariantExplo
                         : dictionary.set.tooltipDataExplo
                 }


### PR DESCRIPTION
# fix(venn): manage somatic in venn

[SKFP-1504](https://ferlab-crsj.atlassian.net/browse/SKFP-1504)

## Description
Manage somatic variant un Venn diagram

## Acceptance Criterias
- display somatic icon in both tables
- display the correct tooltip

<img width="1519" alt="Capture d’écran, le 2025-04-17 à 14 13 24" src="https://github.com/user-attachments/assets/c3a6a1f0-b478-4abc-ac4d-c71ea5a9f3ad" />
