### PR TITLE
feat(querytool): SJIP-1334 always display compare button

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,4 +1,7 @@
 ### 10.23.1 2025-04-17
+- feat: SJIP-1334 always display compare button
+
+### 10.23.1 2025-04-17
 - fix: SKFP-1504 manage somatic in venn diagram
 
 ### 10.23.0 2025-04-17

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.23.1",
+    "version": "10.24.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.23.1",
+            "version": "10.24.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.23.1",
+    "version": "10.24.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/QueryBuilder/QueryTools.tsx
+++ b/packages/ui/src/components/QueryBuilder/QueryTools.tsx
@@ -81,26 +81,27 @@ const QueryTools = ({
                         >
                             {dictionary.actions?.combine || 'Combine'}
                         </Dropdown.Button>
-                        {enableCompare && handleCompare && (
-                            <Tooltip title={isCompareBtnDisabled ? dictionary.actions?.compareTooltips : undefined}>
-                                <Button
-                                    className={cx(styles.button, styles.compare)}
-                                    disabled={isCompareBtnDisabled}
-                                    icon={
-                                        <AndOrIcon
-                                            className={cx(styles.andOrIcon, {
-                                                [styles.disabled]: isCompareBtnDisabled,
-                                            })}
-                                        />
-                                    }
-                                    onClick={handleCompare}
-                                    size="small"
-                                >
-                                    {dictionary.actions?.compare || 'Compare'}
-                                </Button>
-                            </Tooltip>
-                        )}
                     </>
+                )}
+
+                {enableCompare && handleCompare && (
+                    <Tooltip title={isCompareBtnDisabled ? dictionary.actions?.compareTooltips : undefined}>
+                        <Button
+                            className={cx(styles.button, styles.compare)}
+                            disabled={isCompareBtnDisabled}
+                            icon={
+                                <AndOrIcon
+                                    className={cx(styles.andOrIcon, {
+                                        [styles.disabled]: isCompareBtnDisabled,
+                                    })}
+                                />
+                            }
+                            onClick={handleCompare}
+                            size="small"
+                        >
+                            {dictionary.actions?.compare || 'Compare'}
+                        </Button>
+                    </Tooltip>
                 )}
                 {enableShowHideLabels && !canCombine && (
                     <span className={`${styles.switch} ${styles.withLabel}`}>


### PR DESCRIPTION
# feat(querytool): always display compare button

- Closes SJIP-1334

## Description
Goal: Currently, the feature for the venn diagram is fairly hidden. A user needs to select 2-3 queries to be able to have the compare button appear. Therefore, we will always display the Compare button even when there is no selection for the queries. Place it betwene the label button and the new query button with the same styling that it currently has

When <2 queries selected:

Maintain the disable state

tooltip: Select 2 or 3 queries to generate a Venn diagram comparison

When >3 queries selected:

Maintain the disable state

tooltip: Only available with 2 or 3 queries selected

When 2 or 3 queries selected:

Active state as it currently is without a tooltip

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1334)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/967a2e38-6566-422d-8f87-311600855040)
![image](https://github.com/user-attachments/assets/b164dba2-c785-4114-873a-48c4339b8211)
![image](https://github.com/user-attachments/assets/90b1b6cf-03d7-499d-94a7-21fdbcb258e5)
