### PR TITLE
fix(table): SJIP-1336 fix table behaviour on select all pages

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.24.2 2025-04-23
+- fix: SJIP-1336 fix select all page behavior on table
+
 ### 10.24.1 2025-04-23
 - feat: SJIP-1332 various fixes on ven chart with filters
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.1",
+    "version": "10.24.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.24.1",
+            "version": "10.24.2",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.1",
+    "version": "10.24.2",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/index.tsx
+++ b/packages/ui/src/components/ProTable/index.tsx
@@ -171,6 +171,12 @@ const ProTable = <RecordType extends object & { key: string } = any>({
     }, [columns.length, initialColumnState]);
 
     useEffect(() => {
+        if (selectedAllResults) {
+            setSelectedAllResults(false);
+        }
+    }, [selectedRowKeys]);
+
+    useEffect(() => {
         setSelectedRowKeys(initialSelectedKey);
     }, [JSON.stringify(initialSelectedKey)]);
 


### PR DESCRIPTION
# fix(table): fix table behaviour on select all pages

- Closes SJIP-1336

## Description
When using the "Select All Results" option in the table (data Explo, Variant explo), and then manually deselecting a few rows, the "selected" count does not update accordingly.

The select all should be “deactivated” and the selection count should come back to represent the number of rows in the table page. For example in the image below, we have a total of 9431 rows with the Select All, but deselecting 2 rows should “deactivate” the select all and the count should be representative of the page results so it would be 18 items selected (assuming I have a page view of 20).

Problem occurs in all projects

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1336)

## Screenshot or Video

https://github.com/user-attachments/assets/630e0d5b-a42b-4a34-b571-48566bbb62a8

