### PR TITLE
fix(venn): SJIP1356 reset select table set when venn chart is reloaded

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.24.8 2025-05-14
+- fix: SJIP-1356 reset select table set when venn chart is reloaded
+
 ### 10.24.7 2025-05-08
 - feat: SJIP-1354 add avatar to list item with actions
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.7",
+    "version": "10.24.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.24.7",
+            "version": "10.24.8",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.7",
+    "version": "10.24.8",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/VennChartWithFilters/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/VennChartWithFilters/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { UndoOutlined } from '@ant-design/icons';
 import { Button, Select, Tag, Tooltip, Typography } from 'antd';
 import cx from 'classnames';
@@ -81,6 +81,10 @@ const VennChartWithFilters = ({
     const [entityCompared, setEntityCompared] = useState<string>(entitySelected);
     const [setIdsCompared, setSetIdsCompared] = useState<string[]>(idsSelected);
     const [openSetsDropdown, setOpenSetsDropdown] = useState<boolean>(false);
+
+    useEffect(() => {
+        setTableSelectedSets([]);
+    }, [loading]);
 
     if (loading) {
         return <VennWithFilterSkeleton />;

--- a/packages/ui/src/components/Charts/Venn/VennChartWithSelect.tsx
+++ b/packages/ui/src/components/Charts/Venn/VennChartWithSelect.tsx
@@ -153,10 +153,10 @@ const VennChartWithSelect = ({
                         value={entity}
                     >
                         {options.map((option) => (
-                            <option value={option.value}>
+                            <Select.Option key={option.value} value={option.value}>
                                 <span className={styles.optionIcon}>{option.icon}</span>
                                 <span>{option.label}</span>
-                            </option>
+                            </Select.Option>
                         ))}
                     </Select>
                 </div>

--- a/packages/ui/src/components/Charts/Venn/VennQueryPill.tsx
+++ b/packages/ui/src/components/Charts/Venn/VennQueryPill.tsx
@@ -93,7 +93,7 @@ const VennQueryPill = ({ sqon }: TVennQueryPill): JSX.Element => {
         <>
             {valueFilter.map(({ field, op, value }, index) => (
                 <>
-                    <PillTag dictionary={dictionary} field={field} operator={op} value={value} />
+                    <PillTag dictionary={dictionary} field={field} key={field} operator={op} value={value} />
                     {index < valueFilter.length - 1 && <span className={styles.op}>{sqon.op}</span>}
                 </>
             ))}


### PR DESCRIPTION
# fix(venn): SJIP1356 reset select table set when venn chart is reloaded


## Description
Si on sélectionne un set et qu’on compare d’autres données, le set sélectionné reste actif. Le coches devraient se réinitialiser au changement de données.


## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/)


## Screenshot or Video

https://github.com/user-attachments/assets/52852394-3774-4d05-b4da-6c330b6663df

