### PR TITLE
fix(chart): SKFP-1527 add custom legends with patterns

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.24.10 2025-05-23
+- fix: SKFP-1527 use custom legend with patterns
+
 ### 10.24.9 2025-05-14
 - fix: SKFP-1524 fix an issue where vennQueryPill display the wrong tooltips for savedSet
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.9",
+    "version": "10.24.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.24.9",
+            "version": "10.24.10",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.9",
+    "version": "10.24.10",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/LegendSymbol/index.tsx
+++ b/packages/ui/src/components/Charts/LegendSymbol/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { type SymbolProps } from '@nivo/legends';
+
+import { defs } from '../patterns';
+
+interface ILegendSymbol extends SymbolProps {
+    data: { id: string }[];
+}
+
+const LegendSymbol = ({
+    borderColor,
+    borderWidth,
+    data,
+    fill,
+    id,
+    opacity,
+    size,
+    x,
+    y,
+}: ILegendSymbol): React.ReactElement => {
+    const index = data.findIndex((d) => d.id === id);
+    const def = defs[index % defs.length];
+
+    return (
+        <>
+            <rect fill={fill} height={size} stroke={borderColor} strokeWidth={borderWidth} width={size} x={x} y={y} />
+            <rect
+                fill={`url(#${def.id}.bg.${fill})`}
+                height={size}
+                stroke={borderColor}
+                strokeWidth={borderWidth}
+                style={{ pointerEvents: 'none' }}
+                width={size}
+                x={x}
+                y={y}
+            />
+        </>
+    );
+};
+
+export default LegendSymbol;


### PR DESCRIPTION
# fix(chart): add custom legends with patterns

- Closes SKFP-1527

## Description
When downloading pie charts via the download png of the summary view,  there seems to be missing the accessibility patterns in the legend. Add the same accessbility patterns seen in the pie charts to the legend.

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SKFP-1527)

## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/79ab7e7f-472b-4413-a366-b152157b4c67)
### After
![image](https://github.com/user-attachments/assets/c820bf97-7d13-4119-b94d-1614d24ed8d8)
