### PR TITLE
feat(widget): SKFP-1530 remove warning for request biospecimen

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.0 2025-05-29
+- feat: SKFP-1530 remove warning for request biospecimen
+
 ### 10.24.10 2025-05-23
 - fix: SKFP-1527 use custom legend with patterns
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.10",
+    "version": "10.25.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.24.10",
+            "version": "10.25.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.24.10",
+    "version": "10.25.0",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Widgets/BiospecimenRequests/index.tsx
+++ b/packages/ui/src/components/Widgets/BiospecimenRequests/index.tsx
@@ -32,13 +32,6 @@ export const DEFAULT_BIOSPECIMEN_REQUESTS_WIDGET_DICTIONARY: TBiospecimenRequest
             title: 'Permanently delete this biospecimen request?',
         },
         edit: DEFAULT_EDIT_BIOSPECIMENT_REQUEST_MODAL,
-        share: {
-            cancelText: 'Cancel',
-            content:
-                'Note that anyone with this link will have access to: The biospecimen request title The list of biospecimens in the request',
-            okText: 'Copy Link',
-            title: 'Share link to biospecimen request?',
-        },
     },
     noBiospecimenRequests:
         'A history of your biospecimen requests will be listed here. You can make your first request from Data Exploration.',
@@ -62,12 +55,6 @@ type TBiospecimenRequestsWidgetDictionary = {
     modal: {
         edit: TEditBiospecimenRequestModalDictionary;
         delete: {
-            title: string;
-            okText: string;
-            content: string;
-            cancelText: string;
-        };
-        share: {
             title: string;
             okText: string;
             content: string;
@@ -146,11 +133,7 @@ const BiospecimenRequestsWidget = ({
                                         }}
                                         onEdit={() => setEditedBiospecimenRequest(item)}
                                         onShare={() => {
-                                            Modal.confirm({
-                                                ...dictionary.modal.share,
-                                                onOk: () => handleListItemShare(item.id),
-                                                width: 440,
-                                            });
+                                            handleListItemShare(item.id);
                                         }}
                                         title={item.tag}
                                         titleClassName={styles.listItemTitle}


### PR DESCRIPTION
# feat(widget): remove warning for request biospecimen

- Closes SKFP-1530

## Description
We will remove the concept of a private saved sets. All sets will be set to public and will be shareable as part of a shared filter. 

Note:

Remove the warning modal after clicking on the share button of the Biospecimen. Upon clicking on the share button, display a toaste


## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SKFP-1530)



## Screenshot or Video

https://github.com/user-attachments/assets/a3dba23a-1867-4821-a449-9aa3d9ce0060

