### PR TITLE
fix(statistics): SJIP-1370 increase demographic legend width

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.1 2025-06-11
+- fix: SJIP-1370 increase legend width for demographic chart
+
 ### 10.25.0 2025-05-29
 - feat: SKFP-1530 remove warning for request biospecimen
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.0",
+    "version": "10.25.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.0",
+            "version": "10.25.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.0",
+    "version": "10.25.1",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/EntityPage/EntityStatistics/index.tsx
+++ b/packages/ui/src/pages/EntityPage/EntityStatistics/index.tsx
@@ -518,7 +518,7 @@ const getStatisticLayouts = (statistic: TStatistic, dictionary: TEntityStatistic
                                                 anchor: 'bottom',
                                                 direction: 'column',
                                                 itemHeight: LEGEND_ITEM_HEIGHT,
-                                                itemWidth: 100,
+                                                itemWidth: 210,
                                                 translateX: 0,
                                                 translateY:
                                                     (LEGEND_ITEM_HEIGHT * statistic.demography.race.length - 1) / 2,

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,7 +47,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.24.6",
+            "version": "10.25.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",


### PR DESCRIPTION
# fix(statistics): increase demographic legend width

[SJIP-1370](https://ferlab-crsj.atlassian.net/browse/SJIP-1370)

## Description
Race demographic chart is sliced in download png.

## Acceptance Criterias
- See the legend

## Screenshot or Video
### Before
<img width="1727" alt="Capture d’écran, le 2025-06-11 à 08 34 37" src="https://github.com/user-attachments/assets/d5206117-5fdb-4851-8e73-c7fada7ceffc" />

### After
<img width="1727" alt="Capture d’écran, le 2025-06-11 à 08 29 56" src="https://github.com/user-attachments/assets/f94eefcc-ad77-4263-8f40-89b54360883f" />
