### PR TITLE
feat(statistics): SJIP-1372 render optionnal hpo and mondo

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.4 2025-06-20
+- feat: SJIP-1372 entity statistic hpo and mondo optionnal
+
 ### 10.25.3 2025-06-17
 - feat: SJIP-1379 improve statistic download data 
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.3",
+    "version": "10.25.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.3",
+            "version": "10.25.4",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.3",
+    "version": "10.25.4",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
# feat(statistics): render optionnal hpo and mondo

[SJIP-1372](https://ferlab-crsj.atlassian.net/browse/SJIP-1372)

## Description
Remove HPO and Mondo graphs in public study entity.

## Acceptance Criterias
Render optionnal HPO and mondo graphs in Stistics entity.

## Screenshot or Video
### Before
NA

### After
<img width="1726" alt="Capture d’écran, le 2025-06-20 à 14 49 01" src="https://github.com/user-attachments/assets/f5bac9d4-4d6f-478f-a42a-74640323ea2e" />
