### PR TITLE
feat(chart): SJIP-1335 add data in tree node to chart

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.5 2025-06-30
+- feat: SJIP-1335 add data in tree node to chart
+
 ### 10.25.4 2025-06-20
 - feat: SJIP-1372 entity statistic hpo and mondo optionnal
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.4",
+    "version": "10.25.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.4",
+            "version": "10.25.5",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.4",
+    "version": "10.25.5",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/layout/ResizableGridLayout/utils.ts
+++ b/packages/ui/src/layout/ResizableGridLayout/utils.ts
@@ -26,10 +26,11 @@ export const formatAggregationChartData = (data: any[]): any[] =>
     });
 
 export const treeNodeToChartData = (buckets: any[] = []): any[] =>
-    buckets.map(({ exactTagCount, key, name }) => ({
+    buckets.map(({ exactTagCount, key, name, results }) => ({
         id: key,
         label: name,
         value: exactTagCount,
+        valueWithDescendants: results,
     }));
 
 export const observedPhenotypeDefaultGridConfig = {


### PR DESCRIPTION
# feat(chart): add data in tree node to chart

[SJIP-1335](https://ferlab-crsj.atlassian.net/browse/SJIP-1335)

## Description
Enrich tree node data

## Acceptance Criterias
- display multiple values in bar chart tooltip

## Screenshot or Video
NA

### After
<img width="762" alt="Capture d’écran, le 2025-06-30 à 10 51 11" src="https://github.com/user-attachments/assets/211aa306-6370-4d2a-9e0d-4a952ff19b6c" />
