### PR TITLE
feat(table): SKFP-1537 add result suffix to pro table results

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.7 2025-07-03
+- feat: SKFP-1537 add result suffix to pro table results
+
 ### 10.25.6 2025-06-30
 - feat: SJIP-1275 add infoPopover props in resizable grid card
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.6",
+    "version": "10.25.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.6",
+            "version": "10.25.7",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.6",
+    "version": "10.25.7",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/ProTable/Header/ItemsCount/index.tsx
+++ b/packages/ui/src/components/ProTable/Header/ItemsCount/index.tsx
@@ -55,6 +55,7 @@ export const ItemsCount = ({
                         {dictionnary.itemCount?.results || 'Results'} <strong>{formattedFrom}</strong> -{' '}
                         <strong>{formattedTo}</strong> {dictionnary.itemCount?.of || 'of'}{' '}
                         <strong>{formatNumber()}</strong>
+                        {dictionnary.itemCount?.resultSuffix && <span> {dictionnary.itemCount?.resultSuffix}</span>}
                     </span>
                 </Typography.Text>
             )}

--- a/packages/ui/src/components/ProTable/types.ts
+++ b/packages/ui/src/components/ProTable/types.ts
@@ -39,6 +39,7 @@ export interface IProTableDictionary {
         selectAllResults: ReactNode;
         clear: ReactNode;
         clearFilters: ReactNode;
+        resultSuffix?: ReactNode;
     };
     tooltips?: {
         tableExport: ReactNode;

--- a/packages/ui/src/pages/CommunityPage/index.test.tsx
+++ b/packages/ui/src/pages/CommunityPage/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import CommunityMembersPage, { DEFAULT_COMMINUTY_PAGE_DICTIONARY, ISearchParams } from '.';
+import CommunityMembersPage, { DEFAULT_COMMUNITY_PAGE_DICTIONARY } from '.';
 
-const dictionary = DEFAULT_COMMINUTY_PAGE_DICTIONARY;
+const dictionary = DEFAULT_COMMUNITY_PAGE_DICTIONARY;
 
 describe('CommunityMembersPage', () => {
     test('make sure CommunityMembersPage render correctly', () => {

--- a/packages/ui/src/pages/CommunityPage/index.tsx
+++ b/packages/ui/src/pages/CommunityPage/index.tsx
@@ -15,11 +15,12 @@ import styles from './index.module.css';
 
 const { Title } = Typography;
 
-export const DEFAULT_COMMINUTY_PAGE_DICTIONARY = {
+export const DEFAULT_COMMUNITY_PAGE_DICTIONARY = {
     filterBox: DEFAULT_FILTER_BOX_DICTIONARY,
     noResults: 'no result',
     result: 'result',
     results: 'results',
+    resultSuffix: '',
     title: 'Community',
     totalMembers: (members: number): string => `${members} Total Members`,
 };
@@ -31,6 +32,7 @@ export type TCommunityPageDictionary = {
     noResults: string;
     filterBox: TFilterBoxDictionary;
     totalMembers: (members: number) => string;
+    resultSuffix: string;
 };
 
 export interface ISearchParams {
@@ -59,7 +61,7 @@ interface ICommunityPage {
 
 const CommunityMembersPage = ({
     activeFilter,
-    dictionary = DEFAULT_COMMINUTY_PAGE_DICTIONARY,
+    dictionary = DEFAULT_COMMUNITY_PAGE_DICTIONARY,
     handleActiveFilter,
     handlePageChange,
     loading,
@@ -97,6 +99,7 @@ const CommunityMembersPage = ({
                             of: '',
                             result: dictionary.result,
                             results: dictionary.results,
+                            resultSuffix: dictionary.resultSuffix,
                             selectAllResults: '',
                             selected: '',
                             selectedPlural: '',

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -47,7 +47,7 @@
         },
         "../packages/ui": {
             "name": "@ferlab/ui",
-            "version": "10.25.1",
+            "version": "10.25.7",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",


### PR DESCRIPTION
# feat(table): add result suffix to pro table results

[SKFP-1537](https://ferlab-crsj.atlassian.net/browse/SKFP-1537)

## Description
Add suffix after results in community page

## Acceptance Criterias
- Add suffix props to pro table dictionnary

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->

### After
<img width="834" alt="Capture d’écran, le 2025-07-03 à 15 52 09" src="https://github.com/user-attachments/assets/242b5e42-9ef8-40d2-aaea-573c55a52f36" />

