### PR TITLE
feat: CQDG-1157 add studiesBtnProps on Studies Summary on Landing page

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.12 2025-08-08
+- fix: CQDG-1157 add studiesBtnGhost on Studies Summary on Landing page
+
 ### 10.25.11 2025-07-31
 - fix: CLIN-4898 update assignment filter
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.11",
+    "version": "10.25.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.11",
+            "version": "10.25.12",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.11",
+    "version": "10.25.12",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/pages/LandingPage/Studies/Summary/index.tsx
+++ b/packages/ui/src/pages/LandingPage/Studies/Summary/index.tsx
@@ -12,15 +12,16 @@ type TSummaryProps = {
     dictionary: TStudiesDictionary;
     studiesBtnOnClick?: () => void;
     studiesCount: number;
+    studiesBtnGhost?: boolean;
 };
 
-const Summary = ({ dictionary, studiesBtnOnClick, studiesCount }: TSummaryProps): ReactElement => (
+const Summary = ({ dictionary, studiesBtnGhost, studiesBtnOnClick, studiesCount }: TSummaryProps): ReactElement => (
     <div className={styles.container}>
         <TextIcon IconComponent={StudyIcon} size="large" subtitle={dictionary.title} title={studiesCount} />
         <div className={styles.description}>{dictionary.summary}</div>
         {studiesBtnOnClick && (
             <div>
-                <Button onClick={() => studiesBtnOnClick()} size="large" type="primary">
+                <Button ghost={studiesBtnGhost} onClick={() => studiesBtnOnClick()} size="large" type="primary">
                     {dictionary.viewAllBtn || 'View all studies'}
                     <ArrowRightOutlined />
                 </Button>

--- a/packages/ui/src/pages/LandingPage/Studies/index.tsx
+++ b/packages/ui/src/pages/LandingPage/Studies/index.tsx
@@ -25,17 +25,24 @@ export type TStudiesProps = {
     studies: TStudy[];
     studiesBtnOnClick?: () => void;
     studiesCount: number;
+    studiesBtnGhost?: boolean;
 };
 
 const Studies = ({
     autoplaySpeed,
     dictionary,
     studies,
+    studiesBtnGhost,
     studiesBtnOnClick,
     studiesCount,
 }: TStudiesProps): ReactElement => (
     <div className={styles.container}>
-        <Summary dictionary={dictionary} studiesBtnOnClick={studiesBtnOnClick} studiesCount={studiesCount} />
+        <Summary
+            dictionary={dictionary}
+            studiesBtnGhost={studiesBtnGhost}
+            studiesBtnOnClick={studiesBtnOnClick}
+            studiesCount={studiesCount}
+        />
         <Carousel autoplaySpeed={autoplaySpeed} studies={studies} />
     </div>
 );


### PR DESCRIPTION
# feat: add studiesBtnProps on Studies Summary on Landing page

- Closes CQDG-1157

## Description
<!-- Add a description of the changes proposed in the pull request -->

On CQDG we need the ghost primary button on this part

## Acceptance Criterias
<!-- List all acceptance criteria from the ticket -->

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/CQDG-1157)
- [Design](https://)

<img width="577" height="858" alt="Screenshot 2025-08-08 at 10 19 10" src="https://github.com/user-attachments/assets/92daab16-ec81-4bfd-9bcb-1aee350e3449" />
