### PR TITLE
fix: flui-152 venn diag png over scaled

### DIFF
--- a/packages/ui/Release.md
+++ b/packages/ui/Release.md
@@ -1,3 +1,6 @@
+### 10.25.13 2025-08-18
+- fix: FLUI-152 downloaded venn chart png zoomed
+
 ### 10.25.12 2025-08-08
 - fix: CQDG-1157 add studiesBtnGhost on Studies Summary on Landing page
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.12",
+    "version": "10.25.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ferlab/ui",
-            "version": "10.25.12",
+            "version": "10.25.13",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@ant-design/icons": "^4.8.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ferlab/ui",
-    "version": "10.25.12",
+    "version": "10.25.13",
     "description": "Core components for scientific research data portals",
     "publishConfig": {
         "access": "public"

--- a/packages/ui/src/components/Charts/Venn/index.tsx
+++ b/packages/ui/src/components/Charts/Venn/index.tsx
@@ -27,7 +27,7 @@ const SETS_LABELS = ['S₁', 'S₂', 'S₃'];
 const EXPORT_SETTINGS = {
     background: 'white',
     quality: 1,
-    scale: 2,
+    scale: 1,
 };
 const DEFAULT_FILENAME_TEMPLATE = '%name-%type-%date%extension';
 const DEFAULT_FILENAME_DATE_FORMAT = 'yyyy-MM-dd';


### PR DESCRIPTION
https://ferlab-crsj.atlassian.net/browse/FLUI-152
Even on KF/Include the png was overscaled.

I tested the value 1 on safari and its still good


Before:
<img width="805" height="667" alt="Screenshot 2025-08-18 at 10 36 00" src="https://github.com/user-attachments/assets/e11be762-8093-4d39-8814-359f4bd80d88" />


After:
<img width="663" height="489" alt="image" src="https://github.com/user-attachments/assets/ce28494b-b78d-4ee1-b545-52dedb92d185" />
